### PR TITLE
test: align auth tests with current business logic

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,6 +40,15 @@ jobs:
       - name: Run tests and generate coverage
         run: ./gradlew clean test jacocoTestReport
 
+      # JaCoCo XML 리포트를 Codecov로 업로드해 PR에서 커버리지 변화를 확인한다.
+      # 초기 도입 단계이므로 Codecov 업로드 실패가 테스트 CI 실패로 이어지지는 않게 한다.
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./build/reports/jacoco/test/jacocoTestReport.xml
+          fail_ci_if_error: false
+
       # 실패한 CI에서도 테스트/커버리지 결과를 내려받아 원인을 확인할 수 있게 보관한다.
       - name: Upload test and coverage reports
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,52 @@
+# ci.yml: GitHub Actions에서 테스트와 Jacoco 커버리지 리포트를 자동 실행하는 워크플로 파일
+name: CI
+
+on:
+  push:
+    branches:
+      - main
+      - develop
+      - "feature/**"
+  pull_request:
+    branches:
+      - main
+      - develop
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+
+      - name: Setup Gradle
+        uses: gradle/actions/setup-gradle@v4
+
+      - name: Grant execute permission
+        run: chmod +x gradlew
+
+      # 테스트를 실행하고 JaCoCo XML/HTML 리포트를 함께 생성한다.
+      - name: Run tests and generate coverage
+        run: ./gradlew clean test jacocoTestReport
+
+      # 실패한 CI에서도 테스트/커버리지 결과를 내려받아 원인을 확인할 수 있게 보관한다.
+      - name: Upload test and coverage reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: test-and-coverage-reports
+          path: |
+            build/reports/tests/test
+            build/reports/jacoco/test/html
+            build/reports/jacoco/test/jacocoTestReport.xml

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.13'
     id 'io.spring.dependency-management' version '1.1.7'
-    id 'jacoco'
 }
 
 group = 'com.sparta'
@@ -51,17 +50,4 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
-    // 테스트 실행 후 Codecov 업로드와 로컬 확인에 사용할 JaCoCo 리포트를 생성한다.
-    finalizedBy jacocoTestReport
-}
-
-jacocoTestReport {
-    dependsOn test
-
-    reports {
-        // XML은 CI/Codecov 업로드용, HTML은 개발자가 로컬에서 확인하는 용도다.
-        xml.required = true
-        html.required = true
-        csv.required = false
-    }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.5.13'
     id 'io.spring.dependency-management' version '1.1.7'
+    id 'jacoco'
 }
 
 group = 'com.sparta'
@@ -50,4 +51,17 @@ dependencies {
 
 tasks.named('test') {
     useJUnitPlatform()
+    // 테스트 실행 후 Codecov 업로드와 로컬 확인에 사용할 JaCoCo 리포트를 생성한다.
+    finalizedBy jacocoTestReport
+}
+
+jacocoTestReport {
+    dependsOn test
+
+    reports {
+        // XML은 CI/Codecov 업로드용, HTML은 개발자가 로컬에서 확인하는 용도다.
+        xml.required = true
+        html.required = true
+        csv.required = false
+    }
 }

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,19 @@
+# Codecov 결과를 PR에 표시하되, 커버리지 수치로 CI를 실패시키지 않는다.
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 5%
+        informational: true
+    patch:
+      default:
+        target: auto
+        threshold: 5%
+        informational: true
+
+# PR 코멘트에서 전체 커버리지, 변경분, 파일별 변화를 확인할 수 있게 한다.
+comment:
+  layout: "reach,diff,flags,tree"
+  behavior: default
+  require_changes: false

--- a/src/test/java/com/sparta/spartadelivery/auth/application/service/AuthServiceTest.java
+++ b/src/test/java/com/sparta/spartadelivery/auth/application/service/AuthServiceTest.java
@@ -28,6 +28,7 @@ import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.BadCredentialsException;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {
@@ -51,7 +52,6 @@ class AuthServiceTest {
     @DisplayName("회원가입 시 비밀번호를 암호화하고 사용자 정보를 저장한다")
     void signup() {
         ReqSignupDto request = signupRequest();
-        when(userRepository.existsByUsername("user01")).thenReturn(false);
         when(userRepository.existsByEmail("user01@example.com")).thenReturn(false);
         when(passwordEncoder.encode("Password1!")).thenReturn("encoded-password");
         when(userRepository.save(any(UserEntity.class))).thenAnswer(invocation -> invocation.getArgument(0));
@@ -62,34 +62,22 @@ class AuthServiceTest {
         verify(userRepository).save(userCaptor.capture());
         UserEntity savedUser = userCaptor.getValue();
         assertThat(savedUser.getUsername()).isEqualTo("user01");
+        assertThat(savedUser.getNickname()).isEqualTo("유저01");
+        assertThat(savedUser.getEmail()).isEqualTo("user01@example.com");
         assertThat(savedUser.getPassword()).isEqualTo("encoded-password");
         assertThat(savedUser.getPassword()).isNotEqualTo("Password1!");
+        assertThat(savedUser.getRole()).isEqualTo(Role.CUSTOMER);
+        assertThat(savedUser.isPublic()).isTrue();
         assertThat(response.username()).isEqualTo("user01");
+        assertThat(response.nickname()).isEqualTo("유저01");
         assertThat(response.email()).isEqualTo("user01@example.com");
         assertThat(response.role()).isEqualTo(Role.CUSTOMER);
-    }
-
-    @Test
-    @DisplayName("이미 사용 중인 사용자 ID이면 회원가입을 거부한다")
-    void signupWithDuplicateUsername() {
-        ReqSignupDto request = signupRequest();
-        when(userRepository.existsByUsername("user01")).thenReturn(true);
-
-        assertThatThrownBy(() -> authService.signup(request))
-                .isInstanceOf(AppException.class)
-                .extracting("errorCode")
-                .isEqualTo(ErrorCode.DUPLICATE_USERNAME);
-
-        verify(userRepository, never()).existsByEmail(any());
-        verify(passwordEncoder, never()).encode(any());
-        verify(userRepository, never()).save(any());
     }
 
     @Test
     @DisplayName("이미 사용 중인 이메일이면 회원가입을 거부한다")
     void signupWithDuplicateEmail() {
         ReqSignupDto request = signupRequest();
-        when(userRepository.existsByUsername("user01")).thenReturn(false);
         when(userRepository.existsByEmail("user01@example.com")).thenReturn(true);
 
         assertThatThrownBy(() -> authService.signup(request))
@@ -105,7 +93,7 @@ class AuthServiceTest {
     @DisplayName("로그인 성공 시 인증 후 JWT access token을 발급한다")
     void login() {
         ReqLoginDto request = new ReqLoginDto("user01@example.com", "Password1!");
-        UserEntity user = createUser("user01", "user01@example.com", Role.CUSTOMER);
+        UserEntity user = createUser(1L, "user01", "user01@example.com", Role.CUSTOMER);
         when(userRepository.findByEmailAndDeletedAtIsNull("user01@example.com")).thenReturn(Optional.of(user));
         when(jwtTokenProvider.generateAccessToken(any(UserPrincipal.class))).thenReturn("access-token");
 
@@ -114,6 +102,13 @@ class AuthServiceTest {
         verify(authenticationManager).authenticate(
                 new UsernamePasswordAuthenticationToken("user01@example.com", "Password1!")
         );
+        ArgumentCaptor<UserPrincipal> principalCaptor = ArgumentCaptor.forClass(UserPrincipal.class);
+        verify(jwtTokenProvider).generateAccessToken(principalCaptor.capture());
+        UserPrincipal principal = principalCaptor.getValue();
+        assertThat(principal.getId()).isEqualTo(1L);
+        assertThat(principal.getAccountName()).isEqualTo("user01");
+        assertThat(principal.getUsername()).isEqualTo("user01@example.com");
+        assertThat(principal.getRole()).isEqualTo(Role.CUSTOMER);
         assertThat(response.accessToken()).isEqualTo("access-token");
         assertThat(response.username()).isEqualTo("user01");
         assertThat(response.role()).isEqualTo(Role.CUSTOMER);
@@ -135,6 +130,23 @@ class AuthServiceTest {
         verify(jwtTokenProvider, never()).generateAccessToken(any());
     }
 
+    @Test
+    @DisplayName("인증은 성공했지만 사용자를 찾을 수 없으면 로그인을 거부한다")
+    void loginWithMissingUser() {
+        ReqLoginDto request = new ReqLoginDto("user01@example.com", "Password1!");
+        when(userRepository.findByEmailAndDeletedAtIsNull("user01@example.com")).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.login(request))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+
+        verify(authenticationManager).authenticate(
+                new UsernamePasswordAuthenticationToken("user01@example.com", "Password1!")
+        );
+        verify(jwtTokenProvider, never()).generateAccessToken(any());
+    }
+
     private ReqSignupDto signupRequest() {
         return new ReqSignupDto(
                 "user01",
@@ -145,8 +157,8 @@ class AuthServiceTest {
         );
     }
 
-    private UserEntity createUser(String username, String email, Role role) {
-        return UserEntity.builder()
+    private UserEntity createUser(Long id, String username, String email, Role role) {
+        UserEntity user = UserEntity.builder()
                 .username(username)
                 .nickname("유저01")
                 .email(email)
@@ -154,5 +166,7 @@ class AuthServiceTest {
                 .role(role)
                 .isPublic(true)
                 .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
     }
 }

--- a/src/test/java/com/sparta/spartadelivery/auth/presentation/dto/request/AuthRequestValidationTest.java
+++ b/src/test/java/com/sparta/spartadelivery/auth/presentation/dto/request/AuthRequestValidationTest.java
@@ -34,7 +34,7 @@ class AuthRequestValidationTest {
     @DisplayName("회원가입 요청이 입력 조건을 만족하지 않으면 필드별 검증 메시지를 반환한다")
     void invalidSignupRequest() {
         ReqSignupDto request = new ReqSignupDto(
-                "usr",
+                "u",
                 "password",
                 "",
                 "invalid-email",
@@ -46,7 +46,7 @@ class AuthRequestValidationTest {
                 .collect(Collectors.toSet());
 
         assertThat(messages).contains(
-                "username: 사용자 ID는 4~10자여야 합니다.",
+                "username: 사용자 이름은 2~10자여야 합니다.",
                 "password: 비밀번호는 8~15자의 영문 대소문자, 숫자, 특수문자를 모두 포함해야 합니다.",
                 "nickname: 닉네임은 필수입니다.",
                 "email: 이메일 형식이 올바르지 않습니다.",

--- a/src/test/java/com/sparta/spartadelivery/global/entity/BaseEntityTest.java
+++ b/src/test/java/com/sparta/spartadelivery/global/entity/BaseEntityTest.java
@@ -61,17 +61,18 @@ class BaseEntityTest {
 
     @Test
     @DisplayName("엔티티 수정 시 수정 시간이 갱신된다")
-    void update() {
+    void update() throws InterruptedException {
         setAuthentication(TEST_AUDITOR);
         BaseEntityTestEntity savedEntity = repository.saveAndFlush(new BaseEntityTestEntity("before-name"));
         var createdAt = savedEntity.getCreatedAt();
         var beforeUpdatedAt = savedEntity.getUpdatedAt();
 
+        Thread.sleep(10);
         savedEntity.updateName("after-name");
         BaseEntityTestEntity updatedEntity = repository.saveAndFlush(savedEntity);
 
         assertThat(updatedEntity.getCreatedAt()).isEqualTo(createdAt);
-        assertThat(updatedEntity.getUpdatedAt()).isAfterOrEqualTo(beforeUpdatedAt);
+        assertThat(updatedEntity.getUpdatedAt()).isAfter(beforeUpdatedAt);
         assertThat(updatedEntity.getUpdatedBy()).isEqualTo(TEST_AUDITOR);
     }
 

--- a/src/test/java/com/sparta/spartadelivery/global/infrastructure/config/security/JwtAuthenticationFilterTest.java
+++ b/src/test/java/com/sparta/spartadelivery/global/infrastructure/config/security/JwtAuthenticationFilterTest.java
@@ -29,6 +29,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.mock.web.MockHttpServletResponse;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
 class JwtAuthenticationFilterTest {
@@ -72,7 +73,7 @@ class JwtAuthenticationFilterTest {
         request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer valid-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
         CountingFilterChain filterChain = new CountingFilterChain();
-        UserEntity user = createUser("customer", Role.CUSTOMER);
+        UserEntity user = createUser(1L, "customer", Role.CUSTOMER);
 
         when(jwtTokenProvider.getPayload("valid-token"))
                 .thenReturn(new JwtTokenProvider.TokenPayload(1L, "customer", Role.CUSTOMER));
@@ -84,7 +85,10 @@ class JwtAuthenticationFilterTest {
         assertThat(filterChain.isCalled()).isTrue();
         assertThat(authentication).isNotNull();
         assertThat(authentication.getPrincipal()).isInstanceOf(UserPrincipal.class);
-        assertThat(((UserPrincipal) authentication.getPrincipal()).getAccountName()).isEqualTo("customer");
+        UserPrincipal principal = (UserPrincipal) authentication.getPrincipal();
+        assertThat(principal.getId()).isEqualTo(1L);
+        assertThat(principal.getAccountName()).isEqualTo("customer");
+        assertThat(principal.getRole()).isEqualTo(Role.CUSTOMER);
         verifyNoInteractions(errorResponder);
     }
 
@@ -118,9 +122,33 @@ class JwtAuthenticationFilterTest {
         request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer stale-token");
         MockHttpServletResponse response = new MockHttpServletResponse();
         CountingFilterChain filterChain = new CountingFilterChain();
-        UserEntity user = createUser("changed", Role.CUSTOMER);
+        UserEntity user = createUser(1L, "changed", Role.CUSTOMER);
 
         when(jwtTokenProvider.getPayload("stale-token"))
+                .thenReturn(new JwtTokenProvider.TokenPayload(1L, "customer", Role.CUSTOMER));
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
+
+        jwtAuthenticationFilter.doFilter(request, response, filterChain);
+
+        assertThat(filterChain.isCalled()).isFalse();
+        assertThat(SecurityContextHolder.getContext().getAuthentication()).isNull();
+        verify(errorResponder).write(
+                response,
+                ErrorCode.ROLE_REVALIDATION_FAILED.getStatus().value(),
+                ErrorCode.ROLE_REVALIDATION_FAILED.getMessage()
+        );
+    }
+
+    @Test
+    @DisplayName("토큰 권한이 현재 사용자 권한과 다르면 인증 정보를 비우고 오류 응답을 작성한다")
+    void rejectWhenTokenRoleChanged() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.addHeader(HttpHeaders.AUTHORIZATION, "Bearer stale-role-token");
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        CountingFilterChain filterChain = new CountingFilterChain();
+        UserEntity user = createUser(1L, "customer", Role.OWNER);
+
+        when(jwtTokenProvider.getPayload("stale-role-token"))
                 .thenReturn(new JwtTokenProvider.TokenPayload(1L, "customer", Role.CUSTOMER));
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(user));
 
@@ -157,8 +185,8 @@ class JwtAuthenticationFilterTest {
         );
     }
 
-    private UserEntity createUser(String username, Role role) {
-        return UserEntity.builder()
+    private UserEntity createUser(Long id, String username, Role role) {
+        UserEntity user = UserEntity.builder()
                 .username(username)
                 .nickname("nickname")
                 .email(username + "@example.com")
@@ -166,6 +194,8 @@ class JwtAuthenticationFilterTest {
                 .role(role)
                 .isPublic(true)
                 .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
     }
 
     private static class CountingFilterChain implements FilterChain {


### PR DESCRIPTION
회원가입 및 로그인 관련 로직 변경이 있었습니다. 

**[이전 로직]**
- username을 로그인 아이디로 하여 로그인.
- username은 "4~10자의 알파벳 소문자 및 숫자"이어야 함.
- username은 중복 될 수 없음.

**[수정된 로직]**
- email을 로그인 아이디로 하여 로그인.
- username은 2~4자이기만 하면 됨.
- username의 중복을 허용함.

비즈니스 로직의 변경에 따라 레거시 테스트 코드를 수정했습니다. 