### PR TITLE
[refactor] exception 인터페이스 분리

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/global/exception/AppException.java
+++ b/src/main/java/com/sparta/spartadelivery/global/exception/AppException.java
@@ -1,12 +1,13 @@
 package com.sparta.spartadelivery.global.exception;
 
+import com.sparta.spartadelivery.global.exception.code.BaseErrorCode;
 import lombok.Getter;
 
 // 서비스/인증/도메인 로직에서 의도적으로 던지는 Exception을 ErrorCode와 함께 표현하는 클래스
 @Getter
 public class AppException extends RuntimeException {
 
-    private final ErrorCode errorCode;
+    private final BaseErrorCode errorCode;
 
     public AppException(ErrorCode errorCode) {
         super(errorCode.getMessage());

--- a/src/main/java/com/sparta/spartadelivery/global/exception/ErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/global/exception/ErrorCode.java
@@ -1,10 +1,11 @@
 package com.sparta.spartadelivery.global.exception;
 
+import com.sparta.spartadelivery.global.exception.code.BaseErrorCode;
 import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
 @Getter
-public enum ErrorCode {
+public enum ErrorCode implements BaseErrorCode {
     VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "VALIDATION_ERROR"),
     INVALID_REQUEST(HttpStatus.BAD_REQUEST, "INVALID_REQUEST"),
     INVALID_CREDENTIALS(HttpStatus.UNAUTHORIZED, "INVALID_CREDENTIALS"),

--- a/src/main/java/com/sparta/spartadelivery/global/exception/code/BaseErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/global/exception/code/BaseErrorCode.java
@@ -1,0 +1,8 @@
+package com.sparta.spartadelivery.global.exception.code;
+
+import org.springframework.http.HttpStatus;
+
+public interface BaseErrorCode {
+    String getMessage();
+    HttpStatus getStatus();
+}


### PR DESCRIPTION
## 관련 이슈
#12 

## 작업 내용
> 기존 코드 수정 없이 BaseErrorCode 만 상속 받아 사용하시면 됩니다.
> 추가로 다른 도메인에 ErrorCode가 필요할 경우 위를 이용해 enum 값을 정의하시면 됩니다.