### PR TITLE
[Feat #25] 회원 정보 수정  API 구현

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/user/application/service/UserService.java
+++ b/src/main/java/com/sparta/spartadelivery/user/application/service/UserService.java
@@ -3,8 +3,10 @@ package com.sparta.spartadelivery.user.application.service;
 import com.sparta.spartadelivery.auth.exception.AuthErrorCode;
 import com.sparta.spartadelivery.global.exception.AppException;
 import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.user.domain.entity.Role;
 import com.sparta.spartadelivery.user.domain.entity.UserEntity;
 import com.sparta.spartadelivery.user.domain.repository.UserRepository;
+import com.sparta.spartadelivery.user.exception.UserErrorCode;
 import com.sparta.spartadelivery.user.presentation.dto.request.ReqUpdateUserDto;
 import com.sparta.spartadelivery.user.presentation.dto.response.ResUpdateUserDto;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +35,49 @@ public class UserService {
         }
         return ResUpdateUserDto.from(user);
     }
+
+    // 사용자의 정보 수정 API (MANAGER, MASTER만 사용 가능)
+    @Transactional
+    public ResUpdateUserDto updateUser(Long userId, ReqUpdateUserDto request, UserPrincipal requester) {
+        // 대상 사용자가 없으면 USER_NOT_FOUND로 처리한다.
+        UserEntity targetUser = userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new AppException(AuthErrorCode.USER_NOT_FOUND));
+
+        validateManagePermission(requester, targetUser);
+        validateAdminUpdateFields(request);
+        validateDuplicateEmail(request, targetUser);
+
+        targetUser.updateProfile(request.username(), request.nickname(), request.email(), request.isPublic());
+
+        return ResUpdateUserDto.from(targetUser);
+    }
+
+    private void validateManagePermission(UserPrincipal requester, UserEntity targetUser) {
+        // MASTER는 모든 사용자 정보를 수정할 수 있도록 한다
+        if (requester.getRole() == Role.MASTER) {
+            return;
+        }
+        if (requester.getRole() == Role.MANAGER) {
+            // MANAGER는 CUSTOMER, OWNER 사용자의 정보만 수정할 수 있도록 한다.
+            if (canManagerUpdate(targetUser)) {
+                return;
+            }
+            throw new AppException(UserErrorCode.MANAGER_TARGET_ACCESS_DENIED);
+        } // MANAGER 또는 MASTER가 아닌 일반 사용자는 다른 사용자의 정보를 수정할 권한이 없다.
+        throw new AppException(UserErrorCode.USER_UPDATE_ACCESS_DENIED);
+    }
+
+    private void validateAdminUpdateFields(ReqUpdateUserDto request) {
+        // MANAGER와 MASTER는 사용자의 비밀번호를 수정할 수 없다.
+        if (request.hasPasswordUpdate()) {
+            throw new AppException(UserErrorCode.MANAGER_OR_MASTER_CAN_NOT_CHANGE_USERS_PASSWORD);
+        }
+    }
+
+    private boolean canManagerUpdate(UserEntity targetUser) {
+        return targetUser.getRole() == Role.CUSTOMER || targetUser.getRole() == Role.OWNER;
+    }
+
 
     // 이메일 변경 시 중복 이메일 검증을 수행한다.
     private void validateDuplicateEmail(ReqUpdateUserDto request, UserEntity targetUser) {

--- a/src/main/java/com/sparta/spartadelivery/user/application/service/UserService.java
+++ b/src/main/java/com/sparta/spartadelivery/user/application/service/UserService.java
@@ -1,0 +1,48 @@
+package com.sparta.spartadelivery.user.application.service;
+
+import com.sparta.spartadelivery.auth.exception.AuthErrorCode;
+import com.sparta.spartadelivery.global.exception.AppException;
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.user.domain.entity.UserEntity;
+import com.sparta.spartadelivery.user.domain.repository.UserRepository;
+import com.sparta.spartadelivery.user.presentation.dto.request.ReqUpdateUserDto;
+import com.sparta.spartadelivery.user.presentation.dto.response.ResUpdateUserDto;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final PasswordEncoder passwordEncoder;
+
+    // 본인 정보 수정 API (CUSTOMER, OWNER, MANAGER, MASTER 모두 사용 가능)
+    @Transactional
+    public ResUpdateUserDto updateMe(ReqUpdateUserDto request, UserPrincipal requester) {
+        // 대상 사용자가 없으면 USER_NOT_FOUND로 처리한다.
+        UserEntity user = userRepository.findByIdAndDeletedAtIsNull(requester.getId())
+                .orElseThrow(() -> new AppException(AuthErrorCode.USER_NOT_FOUND));
+
+        validateDuplicateEmail(request, user);
+        user.updateProfile(request.username(), request.nickname(), request.email(), request.isPublic());
+        if (request.hasPasswordUpdate()) {
+            user.updatePassword(passwordEncoder.encode(request.password()));
+        }
+        return ResUpdateUserDto.from(user);
+    }
+
+    // 이메일 변경 시 중복 이메일 검증을 수행한다.
+    private void validateDuplicateEmail(ReqUpdateUserDto request, UserEntity targetUser) {
+        // 회원 정보 수정 시 이메일을 변경하지 않거나, 이메일이 null인 경우에는 중복 체크를 하지 않는다.
+        if (request.email() == null || request.email().equals(targetUser.getEmail())) {
+            return;
+        }
+        if (userRepository.existsByEmail(request.email())) {
+            throw new AppException(AuthErrorCode.DUPLICATE_EMAIL);
+        }
+    }
+
+}

--- a/src/main/java/com/sparta/spartadelivery/user/domain/entity/UserEntity.java
+++ b/src/main/java/com/sparta/spartadelivery/user/domain/entity/UserEntity.java
@@ -57,4 +57,23 @@ public class UserEntity extends BaseEntity {
         this.role = role;
         this.isPublic = isPublic;
     }
+
+    public void updateProfile(String username, String nickname, String email, Boolean isPublic) {
+        if (username != null) {
+            this.username = username;
+        }
+        if (nickname != null) {
+            this.nickname = nickname;
+        }
+        if (email != null) {
+            this.email = email;
+        }
+        if (isPublic != null) {
+            this.isPublic = isPublic;
+        }
+    }
+
+    public void updatePassword(String password) {
+        this.password = password;
+    }
 }

--- a/src/main/java/com/sparta/spartadelivery/user/domain/repository/UserRepository.java
+++ b/src/main/java/com/sparta/spartadelivery/user/domain/repository/UserRepository.java
@@ -11,7 +11,5 @@ public interface UserRepository extends JpaRepository<UserEntity, Long> {
 
     Optional<UserEntity> findByIdAndDeletedAtIsNull(Long aLong);
 
-    boolean existsByUsername(String username);
-
     boolean existsByEmail(String email);
 }

--- a/src/main/java/com/sparta/spartadelivery/user/exception/UserErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/user/exception/UserErrorCode.java
@@ -8,7 +8,7 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements BaseErrorCode {
     USER_UPDATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "사용자 정보 수정 권한이 없습니다."),
     MANAGER_TARGET_ACCESS_DENIED(HttpStatus.FORBIDDEN, "MANAGER는 CUSTOMER 또는 OWNER 사용자 정보만 수정할 수 있습니다."),
-    MANAGER_OR_MASTER_CAN_NOT_CHANGE_USERS_PASSWORD(HttpStatus.FORBIDDEN,"MANAGER와 MASTER는 사용자의 비밀번호를 수정할 수 없습니다.");
+    MANAGER_OR_MASTER_CAN_NOT_CHANGE_USERS_PASSWORD(HttpStatus.FORBIDDEN, "MANAGER와 MASTER는 사용자의 비밀번호를 수정할 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/sparta/spartadelivery/user/exception/UserErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/user/exception/UserErrorCode.java
@@ -1,0 +1,20 @@
+package com.sparta.spartadelivery.user.exception;
+
+import com.sparta.spartadelivery.global.exception.BaseErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum UserErrorCode implements BaseErrorCode {
+    USER_UPDATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "사용자 정보 수정 권한이 없습니다."),
+    MANAGER_TARGET_ACCESS_DENIED(HttpStatus.FORBIDDEN, "MANAGER는 CUSTOMER 또는 OWNER 사용자 정보만 수정할 수 있습니다."),
+    MANAGER_OR_MASTER_CAN_NOT_CHANGE_USERS_PASSWORD(HttpStatus.FORBIDDEN,"MANAGER와 MASTER는 사용자의 비밀번호를 수정할 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    UserErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/user/presentation/controller/UserController.java
+++ b/src/main/java/com/sparta/spartadelivery/user/presentation/controller/UserController.java
@@ -1,0 +1,105 @@
+package com.sparta.spartadelivery.user.presentation.controller;
+
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.global.presentation.dto.ApiResponse;
+import com.sparta.spartadelivery.user.application.service.UserService;
+import com.sparta.spartadelivery.user.presentation.dto.request.ReqUpdateUserDto;
+import com.sparta.spartadelivery.user.presentation.dto.response.ResUpdateUserDto;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1")
+@RequiredArgsConstructor
+@Tag(name = "User", description = "사용자 정보 수정 API")
+public class UserController {
+
+    private final UserService userService;
+
+    @Operation(
+            summary = "본인 정보 수정 API",
+            description = """
+                    현재 로그인한 사용자의 정보를 수정합니다.
+
+                    **요청 가능 권한**
+
+                    - CUSTOMER
+                    - OWNER
+                    - MANAGER
+                    - MASTER
+
+                    **수정 가능 필드**
+
+                    - username
+                    - nickname
+                    - email
+                    - password
+                    - isPublic
+
+                    **처리 정책**
+
+                    - 이메일을 변경하는 경우 중복 이메일 검증을 수행합니다.
+                    - 비밀번호를 변경하는 경우 BCrypt로 암호화해 저장합니다.
+                    """
+    )
+    @PatchMapping("/user")
+    public ResponseEntity<ApiResponse<ResUpdateUserDto>> updateMe(
+            @Valid @RequestBody ReqUpdateUserDto request,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        ResUpdateUserDto response = userService.updateMe(request, userPrincipal);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), "SUCCESS", response));
+    }
+
+    @Operation(
+            summary = "다른 사용자 정보 수정 API",
+            description = """
+                    MANAGER 또는 MASTER 권한으로 대상 사용자의 정보를 수정합니다.
+
+                    **요청 가능 권한**
+
+                    - MANAGER
+                    - MASTER
+
+                    **대상 사용자 제한**
+
+                    - MANAGER는 CUSTOMER, OWNER 사용자 정보만 수정할 수 있습니다.
+                    - MASTER는 모든 사용자 정보를 수정할 수 있습니다.
+
+                    **수정 가능 필드**
+
+                    - username
+                    - nickname
+                    - email
+                    - isPublic
+
+                    **수정 불가 필드**
+
+                    - password
+                    - role
+
+                    **처리 정책**
+
+                    - 이메일을 변경하는 경우 중복 이메일 검증을 수행합니다.
+                    """
+    )
+    @PatchMapping("/users/{userId}")
+    public ResponseEntity<ApiResponse<ResUpdateUserDto>> updateUser(
+            @PathVariable Long userId,
+            @Valid @RequestBody ReqUpdateUserDto request,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        ResUpdateUserDto response = userService.updateUser(userId, request, userPrincipal);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), "SUCCESS", response));
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/user/presentation/dto/request/ReqUpdateUserDto.java
+++ b/src/main/java/com/sparta/spartadelivery/user/presentation/dto/request/ReqUpdateUserDto.java
@@ -1,0 +1,37 @@
+package com.sparta.spartadelivery.user.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+public record ReqUpdateUserDto(
+
+        @Schema(description = "사용자 이름", example = "홍길동")
+        @Size(min = 2, max = 10, message = "사용자 이름은 2~10자여야 합니다.")
+        String username,
+
+        @Schema(description = "사용자 닉네임", example = "고길동")
+        @Size(max = 100, message = "닉네임은 최대 100자까지 입력할 수 있습니다.")
+        String nickname,
+
+        @Schema(description = "로그인에 사용할 이메일", example = "user01@example.com")
+        @Email(message = "이메일 형식이 올바르지 않습니다.")
+        @Size(max = 255, message = "이메일은 최대 255자까지 입력할 수 있습니다.")
+        String email,
+
+        @Schema(description = "비밀번호. 본인 정보 수정 API에서만 변경할 수 있습니다.", example = "Password1!")
+        @Pattern(
+                regexp = "^(?=.*[a-z])(?=.*[A-Z])(?=.*\\d)(?=.*[^A-Za-z\\d]).{8,15}$",
+                message = "비밀번호는 8~15자의 영문 대소문자, 숫자, 특수문자를 모두 포함해야 합니다."
+        )
+        String password,
+
+        @Schema(description = "프로필 공개 여부", example = "true")
+        Boolean isPublic
+) {
+
+    public boolean hasPasswordUpdate() {
+        return password != null;
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/user/presentation/dto/response/ResUpdateUserDto.java
+++ b/src/main/java/com/sparta/spartadelivery/user/presentation/dto/response/ResUpdateUserDto.java
@@ -1,0 +1,36 @@
+package com.sparta.spartadelivery.user.presentation.dto.response;
+
+import com.sparta.spartadelivery.user.domain.entity.Role;
+import com.sparta.spartadelivery.user.domain.entity.UserEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record ResUpdateUserDto(
+        @Schema(description = "사용자 식별자", example = "1")
+        Long id,
+        @Schema(description = "사용자 이름", example = "홍길동")
+        String username,
+        @Schema(description = "사용자 닉네임", example = "고길동")
+        String nickname,
+        @Schema(description = "사용자 이메일", example = "user01@example.com")
+        String email,
+        @Schema(description = "사용자 권한", example = "CUSTOMER")
+        Role role,
+        @Schema(description = "프로필 공개 여부", example = "true")
+        boolean isPublic,
+        @Schema(description = "마지막 수정 일시", example = "2026-04-18T12:00:00")
+        LocalDateTime updatedAt
+) {
+
+    public static ResUpdateUserDto from(UserEntity user) {
+        return new ResUpdateUserDto(
+                user.getId(),
+                user.getUsername(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getRole(),
+                user.isPublic(),
+                user.getUpdatedAt()
+        );
+    }
+}

--- a/src/test/java/com/sparta/spartadelivery/user/application/service/UserServiceTest.java
+++ b/src/test/java/com/sparta/spartadelivery/user/application/service/UserServiceTest.java
@@ -1,0 +1,327 @@
+package com.sparta.spartadelivery.user.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sparta.spartadelivery.auth.exception.AuthErrorCode;
+import com.sparta.spartadelivery.global.exception.AppException;
+import com.sparta.spartadelivery.global.exception.BaseErrorCode;
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.user.domain.entity.Role;
+import com.sparta.spartadelivery.user.domain.entity.UserEntity;
+import com.sparta.spartadelivery.user.domain.repository.UserRepository;
+import com.sparta.spartadelivery.user.exception.UserErrorCode;
+import com.sparta.spartadelivery.user.presentation.dto.request.ReqUpdateUserDto;
+import java.util.Optional;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    private static final Long USER_ID = 1L;
+    private static final Long MANAGER_ID = 99L;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserService userService;
+
+    @Test
+    @DisplayName("본인은 프로필과 비밀번호를 수정할 수 있다")
+    void updateMe() {
+        UserEntity user = givenUser(Role.CUSTOMER);
+        ReqUpdateUserDto request = fullUpdateRequest();
+        when(userRepository.existsByEmail("user02@example.com")).thenReturn(false);
+        when(passwordEncoder.encode("Password1!")).thenReturn("encoded-password");
+
+        var response = userService.updateMe(request, principal(USER_ID, Role.CUSTOMER));
+
+        assertUpdatedProfile(user);
+        assertThat(user.getPassword()).isEqualTo("encoded-password");
+        assertThat(response.username()).isEqualTo("user02");
+        assertThat(response.nickname()).isEqualTo("유저02");
+        assertThat(response.email()).isEqualTo("user02@example.com");
+        assertThat(response.isPublic()).isFalse();
+    }
+
+    @Test
+    @DisplayName("본인 수정 시 비밀번호가 없으면 기존 비밀번호를 유지한다")
+    void updateMeWithoutPassword() {
+        UserEntity user = givenUser(Role.CUSTOMER);
+        ReqUpdateUserDto request = profileUpdateRequest();
+        when(userRepository.existsByEmail("user02@example.com")).thenReturn(false);
+
+        userService.updateMe(request, principal(USER_ID, Role.CUSTOMER));
+
+        assertUpdatedProfile(user);
+        assertThat(user.getPassword()).isEqualTo("old-password");
+        verify(passwordEncoder, never()).encode(any());
+    }
+
+    @Test
+    @DisplayName("PATCH 요청에서 null 필드는 기존 값을 유지한다")
+    void updateMePartially() {
+        UserEntity user = givenUser(Role.CUSTOMER);
+        ReqUpdateUserDto request = nicknameOnlyRequest();
+
+        userService.updateMe(request, principal(USER_ID, Role.CUSTOMER));
+
+        assertThat(user.getUsername()).isEqualTo("user01");
+        assertThat(user.getNickname()).isEqualTo("새닉네임");
+        assertThat(user.getEmail()).isEqualTo("user01@example.com");
+        assertThat(user.getPassword()).isEqualTo("old-password");
+        assertThat(user.isPublic()).isTrue();
+        verify(userRepository, never()).existsByEmail(any());
+        verify(passwordEncoder, never()).encode(any());
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Role.class, names = {"CUSTOMER", "OWNER"})
+    @DisplayName("MANAGER는 CUSTOMER와 OWNER 사용자 정보를 수정할 수 있다")
+    void updateCustomerOrOwnerByManager(Role targetRole) {
+        UserEntity targetUser = givenUser(targetRole);
+        ReqUpdateUserDto request = profileUpdateRequest();
+        when(userRepository.existsByEmail("user02@example.com")).thenReturn(false);
+
+        var response = userService.updateUser(USER_ID, request, principal(MANAGER_ID, Role.MANAGER));
+
+        assertUpdatedProfile(targetUser);
+        assertThat(targetUser.getPassword()).isEqualTo("old-password");
+        assertThat(response.role()).isEqualTo(targetRole);
+        verify(passwordEncoder, never()).encode(any());
+    }
+
+    @ParameterizedTest
+    @EnumSource(Role.class)
+    @DisplayName("MASTER는 모든 사용자 정보를 수정할 수 있다")
+    void updateAnyUserByMaster(Role targetRole) {
+        UserEntity targetUser = givenUser(targetRole);
+        ReqUpdateUserDto request = usernameOnlyRequest();
+
+        var response = userService.updateUser(USER_ID, request, principal(MANAGER_ID, Role.MASTER));
+
+        assertThat(targetUser.getUsername()).isEqualTo("user02");
+        assertThat(response.role()).isEqualTo(targetRole);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Role.class, names = {"CUSTOMER", "OWNER"})
+    @DisplayName("CUSTOMER와 OWNER는 관리자 사용자 정보 수정 API를 사용할 수 없다")
+    void updateUserByNonAdminDenied(Role requesterRole) {
+        givenUser(Role.CUSTOMER);
+        ReqUpdateUserDto request = usernameOnlyRequest();
+
+        assertAppException(
+                () -> userService.updateUser(USER_ID, request, principal(2L, requesterRole)),
+                UserErrorCode.USER_UPDATE_ACCESS_DENIED
+        );
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Role.class, names = {"MANAGER", "MASTER"})
+    @DisplayName("MANAGER는 MANAGER와 MASTER 사용자 정보를 수정할 수 없다")
+    void updateManagerOrMasterByManagerDenied(Role targetRole) {
+        givenUser(targetRole);
+        ReqUpdateUserDto request = usernameOnlyRequest();
+
+        assertAppException(
+                () -> userService.updateUser(USER_ID, request, principal(MANAGER_ID, Role.MANAGER)),
+                UserErrorCode.MANAGER_TARGET_ACCESS_DENIED
+        );
+    }
+
+    @Test
+    @DisplayName("관리자 사용자 정보 수정 API에서는 비밀번호를 수정할 수 없다")
+    void updatePasswordByAdminDenied() {
+        givenUser(Role.CUSTOMER);
+        ReqUpdateUserDto request = passwordOnlyRequest();
+
+        assertAppException(
+                () -> userService.updateUser(USER_ID, request, principal(MANAGER_ID, Role.MASTER)),
+                UserErrorCode.MANAGER_OR_MASTER_CAN_NOT_CHANGE_USERS_PASSWORD
+        );
+        verify(passwordEncoder, never()).encode(any());
+    }
+
+    @Test
+    @DisplayName("본인 수정 시 이미 사용 중인 이메일이면 수정을 거부한다")
+    void updateMeWithDuplicateEmail() {
+        givenUser(Role.CUSTOMER);
+        ReqUpdateUserDto request = emailOnlyRequest("duplicate@example.com");
+        when(userRepository.existsByEmail("duplicate@example.com")).thenReturn(true);
+
+        assertAppException(
+                () -> userService.updateMe(request, principal(USER_ID, Role.CUSTOMER)),
+                AuthErrorCode.DUPLICATE_EMAIL
+        );
+    }
+
+    @Test
+    @DisplayName("관리자 수정 시 이미 사용 중인 이메일이면 수정을 거부한다")
+    void updateUserWithDuplicateEmail() {
+        givenUser(Role.CUSTOMER);
+        ReqUpdateUserDto request = emailOnlyRequest("duplicate@example.com");
+        when(userRepository.existsByEmail("duplicate@example.com")).thenReturn(true);
+
+        assertAppException(
+                () -> userService.updateUser(USER_ID, request, principal(MANAGER_ID, Role.MASTER)),
+                AuthErrorCode.DUPLICATE_EMAIL
+        );
+    }
+
+    @Test
+    @DisplayName("이메일이 기존 값과 같으면 중복 검증을 수행하지 않는다")
+    void updateWithSameEmailDoesNotCheckDuplicateEmail() {
+        UserEntity user = givenUser(Role.CUSTOMER);
+        ReqUpdateUserDto request = emailOnlyRequest("user01@example.com");
+
+        userService.updateMe(request, principal(USER_ID, Role.CUSTOMER));
+
+        assertThat(user.getEmail()).isEqualTo("user01@example.com");
+        verify(userRepository, never()).existsByEmail(any());
+    }
+
+    @Test
+    @DisplayName("본인 수정 대상 사용자가 없으면 USER_NOT_FOUND로 처리한다")
+    void updateMeWithMissingUser() {
+        ReqUpdateUserDto request = usernameOnlyRequest();
+        when(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).thenReturn(Optional.empty());
+
+        assertAppException(
+                () -> userService.updateMe(request, principal(USER_ID, Role.CUSTOMER)),
+                AuthErrorCode.USER_NOT_FOUND
+        );
+    }
+
+    @Test
+    @DisplayName("관리자 수정 대상 사용자가 없으면 USER_NOT_FOUND로 처리한다")
+    void updateUserWithMissingUser() {
+        ReqUpdateUserDto request = usernameOnlyRequest();
+        when(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).thenReturn(Optional.empty());
+
+        assertAppException(
+                () -> userService.updateUser(USER_ID, request, principal(MANAGER_ID, Role.MANAGER)),
+                AuthErrorCode.USER_NOT_FOUND
+        );
+    }
+
+    private UserEntity givenUser(Role role) {
+        UserEntity user = createUser(USER_ID, role);
+        when(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).thenReturn(Optional.of(user));
+        return user;
+    }
+
+    private ReqUpdateUserDto fullUpdateRequest() {
+        return new ReqUpdateUserDto(
+                "user02",
+                "유저02",
+                "user02@example.com",
+                "Password1!",
+                false
+        );
+    }
+
+    private ReqUpdateUserDto profileUpdateRequest() {
+        return new ReqUpdateUserDto(
+                "user02",
+                "유저02",
+                "user02@example.com",
+                null,
+                false
+        );
+    }
+
+    private ReqUpdateUserDto usernameOnlyRequest() {
+        return new ReqUpdateUserDto("user02", null, null, null, null);
+    }
+
+    private ReqUpdateUserDto nicknameOnlyRequest() {
+        return new ReqUpdateUserDto(null, "새닉네임", null, null, null);
+    }
+
+    private ReqUpdateUserDto passwordOnlyRequest() {
+        return new ReqUpdateUserDto(null, null, null, "Password1!", null);
+    }
+
+    private ReqUpdateUserDto emailOnlyRequest(String email) {
+        return new ReqUpdateUserDto(null, null, email, null, null);
+    }
+
+    private void assertUpdatedProfile(UserEntity user) {
+        assertThat(user.getUsername()).isEqualTo("user02");
+        assertThat(user.getNickname()).isEqualTo("유저02");
+        assertThat(user.getEmail()).isEqualTo("user02@example.com");
+        assertThat(user.isPublic()).isFalse();
+    }
+
+    private void assertAppException(ThrowingCallable callable, BaseErrorCode expectedErrorCode) {
+        assertThatThrownBy(callable)
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(expectedErrorCode);
+    }
+
+    private UserEntity createUser(Long id, Role role) {
+        UserEntity user = UserEntity.builder()
+                .username(defaultUsername(role))
+                .nickname(defaultNickname(role))
+                .email(defaultEmail(role))
+                .password("old-password")
+                .role(role)
+                .isPublic(true)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+
+    private String defaultUsername(Role role) {
+        return switch (role) {
+            case MANAGER -> "manager01";
+            case MASTER -> "master01";
+            case OWNER -> "owner01";
+            case CUSTOMER -> "user01";
+        };
+    }
+
+    private String defaultNickname(Role role) {
+        return switch (role) {
+            case MANAGER -> "매니저01";
+            case MASTER -> "마스터01";
+            case OWNER -> "점주01";
+            case CUSTOMER -> "유저01";
+        };
+    }
+
+    private String defaultEmail(Role role) {
+        return defaultUsername(role) + "@example.com";
+    }
+
+    private UserPrincipal principal(Long id, Role role) {
+        return UserPrincipal.builder()
+                .id(id)
+                .accountName("requester")
+                .password("password")
+                .nickname("요청자")
+                .email("requester@example.com")
+                .role(role)
+                .build();
+    }
+}


### PR DESCRIPTION
#25 

# 🔑 사용자 정보 수정 API

## 📌 공통 사용자 정보 수정

| 항목              | 내용                                                                 |
|-------------------|----------------------------------------------------------------------|
| 요청 가능 권한    | CUSTOMER, OWNER, MANAGER, MASTER                                     |
| 수정 가능 필드    | `username`, `nickname`, `email`, `password`, `isPublic`              |
| 처리 정책         | - 이메일 변경 시 **중복 이메일 검증** 수행<br>- 비밀번호 변경 시 **BCrypt 암호화 후 저장** |

---

## 👥 다른 사용자 정보 수정 (MANAGER / MASTER)

| 항목              | 내용                                                                 |
|-------------------|----------------------------------------------------------------------|
| 요청 가능 권한    | MANAGER, MASTER                                                      |
| 대상 사용자 제한  | - MANAGER → `CUSTOMER`, `OWNER`만 수정 가능<br>- MASTER → 모든 사용자 수정 가능 |
| 수정 가능 필드    | `username`, `nickname`, `email`, `isPublic`                          |
| 수정 불가 필드    | `password`, `role`                                                   |
| 처리 정책         | 이메일 변경 시 **중복 이메일 검증** 수행                             |

---
