### PR TITLE
Issue #39 사용자 상세 조회 API 구현

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/user/application/service/UserService.java
+++ b/src/main/java/com/sparta/spartadelivery/user/application/service/UserService.java
@@ -9,6 +9,7 @@ import com.sparta.spartadelivery.user.domain.repository.UserRepository;
 import com.sparta.spartadelivery.user.exception.UserErrorCode;
 import com.sparta.spartadelivery.user.presentation.dto.request.ReqUpdateUserDto;
 import com.sparta.spartadelivery.user.presentation.dto.request.ReqUpdateUserRoleDto;
+import com.sparta.spartadelivery.user.presentation.dto.response.ResUserDetailDto;
 import com.sparta.spartadelivery.user.presentation.dto.response.ResUserPageDto;
 import com.sparta.spartadelivery.user.presentation.dto.response.ResUpdateUserDto;
 import com.sparta.spartadelivery.user.presentation.dto.response.ResUpdateUserRoleDto;
@@ -39,6 +40,21 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final PasswordEncoder passwordEncoder;
+
+    // 본인 상세 조회 API
+    @Transactional(readOnly = true)
+    public ResUserDetailDto getMe(UserPrincipal requester) {
+        UserEntity user = getActiveUser(requester.getId());
+        return ResUserDetailDto.from(user);
+    }
+
+    // 다른 사용자 상세 조회 API (MANAGER, MASTER만 사용 가능)
+    @Transactional(readOnly = true)
+    public ResUserDetailDto getUser(Long userId, UserPrincipal requester) {
+        validateUserDetailPermission(requester);
+        UserEntity user = getActiveUser(userId);
+        return ResUserDetailDto.from(user);
+    }
 
     // 사용자 목록 조회 API
     @Transactional(readOnly = true)
@@ -123,6 +139,19 @@ public class UserService {
             return;
         }
         throw new AppException(UserErrorCode.USER_LIST_ACCESS_DENIED);
+    }
+
+    private void validateUserDetailPermission(UserPrincipal requester) {
+        if (requester.getRole() == Role.MANAGER || requester.getRole() == Role.MASTER) {
+            return;
+        }
+        throw new AppException(UserErrorCode.USER_DETAIL_ACCESS_DENIED);
+    }
+
+    // 삭제되지 않은 활성 사용자만 상세 조회 대상으로 사용한다.
+    private UserEntity getActiveUser(Long userId) {
+        return userRepository.findByIdAndDeletedAtIsNull(userId)
+                .orElseThrow(() -> new AppException(AuthErrorCode.USER_NOT_FOUND));
     }
 
     private String normalizeKeyword(String keyword) {

--- a/src/main/java/com/sparta/spartadelivery/user/exception/UserErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/user/exception/UserErrorCode.java
@@ -6,6 +6,9 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum UserErrorCode implements BaseErrorCode {
+    // 사용자 상세 조회 API 관련 에러 코드
+    USER_DETAIL_ACCESS_DENIED(HttpStatus.FORBIDDEN, "다른 사용자 정보 상세 조회 권한이 없습니다."),
+
     // 사용자 목록 조회 API 관련 에러 코드
     USER_LIST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "사용자 목록 조회 권한이 없습니다."),
     USER_LIST_INVALID_SORT_FORMAT(HttpStatus.BAD_REQUEST, "정렬 조건은 property,direction 형식이어야 합니다."),
@@ -19,7 +22,7 @@ public enum UserErrorCode implements BaseErrorCode {
     MANAGER_TARGET_ACCESS_DENIED(HttpStatus.FORBIDDEN, "MANAGER는 CUSTOMER 또는 OWNER 사용자 정보만 수정할 수 있습니다."),
     MANAGER_OR_MASTER_CAN_NOT_CHANGE_USERS_PASSWORD(HttpStatus.FORBIDDEN, "MANAGER와 MASTER는 사용자의 비밀번호를 수정할 수 없습니다."),
 
-    // MASTER 전용 사용자 권한 수정 API 관련 에러 코드
+    // 사용자 권한 수정 API 관련 에러 코드
     USER_ROLE_UPDATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "사용자 권한 수정 권한이 없습니다."),
     SELF_ROLE_UPDATE_DENIED(HttpStatus.FORBIDDEN, "자기 자신의 권한은 변경할 수 없습니다.");
 

--- a/src/main/java/com/sparta/spartadelivery/user/presentation/controller/UserAdminController.java
+++ b/src/main/java/com/sparta/spartadelivery/user/presentation/controller/UserAdminController.java
@@ -6,6 +6,7 @@ import com.sparta.spartadelivery.user.application.service.UserService;
 import com.sparta.spartadelivery.user.domain.entity.Role;
 import com.sparta.spartadelivery.user.presentation.dto.request.ReqUpdateUserDto;
 import com.sparta.spartadelivery.user.presentation.dto.request.ReqUpdateUserRoleDto;
+import com.sparta.spartadelivery.user.presentation.dto.response.ResUserDetailDto;
 import com.sparta.spartadelivery.user.presentation.dto.response.ResUserPageDto;
 import com.sparta.spartadelivery.user.presentation.dto.response.ResUpdateUserDto;
 import com.sparta.spartadelivery.user.presentation.dto.response.ResUpdateUserRoleDto;
@@ -53,6 +54,27 @@ public class UserAdminController {
             @RequestParam(required = false) String sort
     ) {
         ResUserPageDto response = userService.getUsers(userPrincipal, keyword, role, page, size, sort);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), response));
+    }
+
+    // 관리자 권한으로 대상 사용자의 상세 정보를 조회한다.
+    @Operation(
+            summary = "다른 사용자 정보 상세 조회 API",
+            description = """
+                    MANAGER 또는 MASTER 권한으로 대상 사용자의 상세 정보를 조회합니다.
+
+                    **요청 가능 권한**
+
+                    - MANAGER
+                    - MASTER
+                    """
+    )
+    @GetMapping("/{userId}")
+    public ResponseEntity<ApiResponse<ResUserDetailDto>> getUser(
+            @PathVariable Long userId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        ResUserDetailDto response = userService.getUser(userId, userPrincipal);
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), response));
     }
 

--- a/src/main/java/com/sparta/spartadelivery/user/presentation/controller/UserController.java
+++ b/src/main/java/com/sparta/spartadelivery/user/presentation/controller/UserController.java
@@ -4,6 +4,7 @@ import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrinc
 import com.sparta.spartadelivery.global.presentation.dto.ApiResponse;
 import com.sparta.spartadelivery.user.application.service.UserService;
 import com.sparta.spartadelivery.user.presentation.dto.request.ReqUpdateUserDto;
+import com.sparta.spartadelivery.user.presentation.dto.response.ResUserDetailDto;
 import com.sparta.spartadelivery.user.presentation.dto.response.ResUpdateUserDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +26,28 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
+
+    // 로그인한 사용자의 본인 상세 정보를 조회한다.
+    @Operation(
+            summary = "본인 정보 상세 조회 API",
+            description = """
+                    현재 로그인한 사용자의 상세 정보를 조회합니다.
+
+                    **요청 가능 권한**
+
+                    - CUSTOMER
+                    - OWNER
+                    - MANAGER
+                    - MASTER
+                    """
+    )
+    @GetMapping("/user")
+    public ResponseEntity<ApiResponse<ResUserDetailDto>> getMe(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        ResUserDetailDto response = userService.getMe(userPrincipal);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), response));
+    }
 
     @Operation(
             summary = "본인 정보 수정 API",

--- a/src/main/java/com/sparta/spartadelivery/user/presentation/dto/response/ResUserDetailDto.java
+++ b/src/main/java/com/sparta/spartadelivery/user/presentation/dto/response/ResUserDetailDto.java
@@ -1,0 +1,40 @@
+package com.sparta.spartadelivery.user.presentation.dto.response;
+
+import com.sparta.spartadelivery.user.domain.entity.Role;
+import com.sparta.spartadelivery.user.domain.entity.UserEntity;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+
+public record ResUserDetailDto(
+        @Schema(description = "사용자 식별자", example = "1")
+        Long id,
+        @Schema(description = "사용자 이름", example = "user01")
+        String username,
+        @Schema(description = "사용자 닉네임", example = "유저01")
+        String nickname,
+        @Schema(description = "사용자 이메일", example = "user01@example.com")
+        String email,
+        @Schema(description = "사용자 권한", example = "CUSTOMER")
+        Role role,
+        @Schema(description = "프로필 공개 여부", example = "true")
+        boolean isPublic,
+        @Schema(description = "가입 일시", example = "2026-04-17T12:00:00")
+        LocalDateTime createdAt,
+        @Schema(description = "마지막 수정 일시", example = "2026-04-18T12:00:00")
+        LocalDateTime updatedAt
+) {
+
+    // 사용자 엔티티를 상세 조회 응답 형식으로 변환한다.
+    public static ResUserDetailDto from(UserEntity user) {
+        return new ResUserDetailDto(
+                user.getId(),
+                user.getUsername(),
+                user.getNickname(),
+                user.getEmail(),
+                user.getRole(),
+                user.isPublic(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
+        );
+    }
+}

--- a/src/test/java/com/sparta/spartadelivery/user/application/service/UserServiceDetailTest.java
+++ b/src/test/java/com/sparta/spartadelivery/user/application/service/UserServiceDetailTest.java
@@ -1,0 +1,119 @@
+package com.sparta.spartadelivery.user.application.service;
+
+import static com.sparta.spartadelivery.user.application.service.UserServiceTestFixture.MANAGER_ID;
+import static com.sparta.spartadelivery.user.application.service.UserServiceTestFixture.USER_ID;
+import static com.sparta.spartadelivery.user.application.service.UserServiceTestFixture.assertAppException;
+import static com.sparta.spartadelivery.user.application.service.UserServiceTestFixture.createUser;
+import static com.sparta.spartadelivery.user.application.service.UserServiceTestFixture.principal;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sparta.spartadelivery.auth.exception.AuthErrorCode;
+import com.sparta.spartadelivery.user.domain.entity.Role;
+import com.sparta.spartadelivery.user.domain.entity.UserEntity;
+import com.sparta.spartadelivery.user.domain.repository.UserRepository;
+import com.sparta.spartadelivery.user.exception.UserErrorCode;
+import com.sparta.spartadelivery.user.presentation.dto.response.ResUserDetailDto;
+import java.util.Optional;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceDetailTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private PasswordEncoder passwordEncoder;
+
+    @InjectMocks
+    private UserService userService;
+
+    @ParameterizedTest
+    @EnumSource(Role.class)
+    @DisplayName("모든 권한은 본인 정보를 상세 조회할 수 있다")
+    void getMeByAnyRole(Role requesterRole) {
+        UserEntity user = createUser(USER_ID, requesterRole);
+        when(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).thenReturn(Optional.of(user));
+
+        var response = userService.getMe(principal(USER_ID, requesterRole));
+
+        assertUserDetailResponse(response, user);
+    }
+
+    @ParameterizedTest
+    @MethodSource("adminRequesterAndTargetRoles")
+    @DisplayName("MANAGER와 MASTER는 모든 권한의 다른 사용자 정보를 상세 조회할 수 있다")
+    void getUserByManagerOrMaster(Role requesterRole, Role targetRole) {
+        UserEntity targetUser = createUser(USER_ID, targetRole);
+        when(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).thenReturn(Optional.of(targetUser));
+
+        var response = userService.getUser(USER_ID, principal(MANAGER_ID, requesterRole));
+
+        assertUserDetailResponse(response, targetUser);
+    }
+
+    @ParameterizedTest
+    @EnumSource(value = Role.class, names = {"CUSTOMER", "OWNER"})
+    @DisplayName("CUSTOMER와 OWNER는 다른 사용자 정보를 상세 조회할 수 없다")
+    void getUserByCustomerOrOwnerDenied(Role requesterRole) {
+        assertAppException(
+                () -> userService.getUser(USER_ID, principal(2L, requesterRole)),
+                UserErrorCode.USER_DETAIL_ACCESS_DENIED
+        );
+        verify(userRepository, never()).findByIdAndDeletedAtIsNull(any());
+    }
+
+    @Test
+    @DisplayName("본인 상세 조회 대상 사용자가 없으면 USER_NOT_FOUND로 처리한다")
+    void getMeWithMissingUser() {
+        when(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).thenReturn(Optional.empty());
+
+        assertAppException(
+                () -> userService.getMe(principal(USER_ID, Role.CUSTOMER)),
+                AuthErrorCode.USER_NOT_FOUND
+        );
+    }
+
+    @Test
+    @DisplayName("다른 사용자 상세 조회 대상 사용자가 없으면 USER_NOT_FOUND로 처리한다")
+    void getUserWithMissingUser() {
+        when(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).thenReturn(Optional.empty());
+
+        assertAppException(
+                () -> userService.getUser(USER_ID, principal(MANAGER_ID, Role.MANAGER)),
+                AuthErrorCode.USER_NOT_FOUND
+        );
+    }
+
+    private static Stream<Arguments> adminRequesterAndTargetRoles() {
+        return Stream.of(Role.MANAGER, Role.MASTER)
+                .flatMap(requesterRole -> Stream.of(Role.values())
+                        .map(targetRole -> Arguments.of(requesterRole, targetRole)));
+    }
+
+    private void assertUserDetailResponse(ResUserDetailDto response, UserEntity user) {
+        assertThat(response.id()).isEqualTo(user.getId());
+        assertThat(response.username()).isEqualTo(user.getUsername());
+        assertThat(response.nickname()).isEqualTo(user.getNickname());
+        assertThat(response.email()).isEqualTo(user.getEmail());
+        assertThat(response.role()).isEqualTo(user.getRole());
+        assertThat(response.isPublic()).isEqualTo(user.isPublic());
+        assertThat(response.createdAt()).isEqualTo(user.getCreatedAt());
+        assertThat(response.updatedAt()).isEqualTo(user.getUpdatedAt());
+    }
+}


### PR DESCRIPTION
Ref #39 

## 📄 작업 내용
사용자 상세 조회 API를 추가했습니다.

- `UserController`에 본인 정보 상세 조회 API를 추가했습니다.
  - `GET /api/v1/user`
  - 로그인한 사용자 본인의 상세 정보를 조회합니다.
  - `CUSTOMER`, `OWNER`, `MANAGER`, `MASTER` 모두 사용 가능합니다.

- `UserAdminController`에 다른 사용자 정보 상세 조회 API를 추가했습니다.
  - `GET /api/v1/users/{userId}`
  - `MANAGER`, `MASTER` 권한으로 대상 사용자의 상세 정보를 조회합니다.

- 사용자 상세 조회 응답 DTO를 추가했습니다.
  - `ResUserDetailDto`
  - `id`, `username`, `nickname`, `email`, `role`, `isPublic`, `createdAt`, `updatedAt`을 응답합니다.

- 사용자 상세 조회 서비스 로직을 추가했습니다.
  - 삭제되지 않은 활성 사용자만 조회합니다.
  - 대상 사용자가 없으면 `USER_NOT_FOUND` 예외를 반환합니다.
  - 다른 사용자 상세 조회 시 `MANAGER`, `MASTER` 권한만 허용합니다.

- 사용자 상세 조회 권한 에러 코드를 추가했습니다.
  - `USER_DETAIL_ACCESS_DENIED`

- 사용자 상세 조회 서비스 테스트를 추가했습니다.
  - 모든 권한의 본인 상세 조회 성공 케이스 검증
  - `MANAGER`, `MASTER`의 다른 사용자 상세 조회 성공 케이스 검증
  - 대상 사용자 권한별 상세 조회 가능 여부 검증
  - `CUSTOMER`, `OWNER`의 다른 사용자 상세 조회 권한 거부 검증
  - 조회 대상 사용자가 없는 경우 예외 처리 검증
  - 상세 조회 응답 필드 매핑 검증