### PR TITLE
Issue # 41 본인 회원 탈퇴 API 구현

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/user/application/service/UserService.java
+++ b/src/main/java/com/sparta/spartadelivery/user/application/service/UserService.java
@@ -56,6 +56,13 @@ public class UserService {
         return ResUserDetailDto.from(user);
     }
 
+    // 본인 회원 탈퇴 API
+    @Transactional
+    public void deleteMe(UserPrincipal requester) {
+        UserEntity user = getActiveUser(requester.getId());
+        user.markDeleted(requester.getAccountName());
+    }
+
     // 사용자 목록 조회 API
     @Transactional(readOnly = true)
     public ResUserPageDto getUsers(
@@ -148,7 +155,6 @@ public class UserService {
         throw new AppException(UserErrorCode.USER_DETAIL_ACCESS_DENIED);
     }
 
-    // 삭제되지 않은 활성 사용자만 상세 조회 대상으로 사용한다.
     private UserEntity getActiveUser(Long userId) {
         return userRepository.findByIdAndDeletedAtIsNull(userId)
                 .orElseThrow(() -> new AppException(AuthErrorCode.USER_NOT_FOUND));

--- a/src/main/java/com/sparta/spartadelivery/user/presentation/controller/UserController.java
+++ b/src/main/java/com/sparta/spartadelivery/user/presentation/controller/UserController.java
@@ -13,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -47,6 +48,32 @@ public class UserController {
     ) {
         ResUserDetailDto response = userService.getMe(userPrincipal);
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), response));
+    }
+
+    // 로그인한 사용자의 본인 계정을 탈퇴 처리한다.
+    @Operation(
+            summary = "본인 회원 탈퇴 API",
+            description = """
+                    현재 로그인한 사용자의 계정을 탈퇴 처리합니다.
+
+                    **요청 가능 권한**
+
+                    - CUSTOMER
+                    - OWNER
+                    - MANAGER
+                    - MASTER
+
+                    **처리 정책**
+
+                    - 실제 데이터를 삭제하지 않고 deletedAt을 기록하는 soft delete 방식으로 처리합니다.
+                    """
+    )
+    @DeleteMapping("/user")
+    public ResponseEntity<ApiResponse<Void>> deleteMe(
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        userService.deleteMe(userPrincipal);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), null));
     }
 
     @Operation(

--- a/src/test/java/com/sparta/spartadelivery/user/application/service/UserServiceDeleteTest.java
+++ b/src/test/java/com/sparta/spartadelivery/user/application/service/UserServiceDeleteTest.java
@@ -1,0 +1,57 @@
+package com.sparta.spartadelivery.user.application.service;
+
+import static com.sparta.spartadelivery.user.application.service.UserServiceTestFixture.USER_ID;
+import static com.sparta.spartadelivery.user.application.service.UserServiceTestFixture.assertAppException;
+import static com.sparta.spartadelivery.user.application.service.UserServiceTestFixture.createUser;
+import static com.sparta.spartadelivery.user.application.service.UserServiceTestFixture.principal;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.sparta.spartadelivery.auth.exception.AuthErrorCode;
+import com.sparta.spartadelivery.user.domain.entity.Role;
+import com.sparta.spartadelivery.user.domain.entity.UserEntity;
+import com.sparta.spartadelivery.user.domain.repository.UserRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class UserServiceDeleteTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserService userService;
+
+    @ParameterizedTest
+    @EnumSource(Role.class)
+    @DisplayName("모든 권한은 본인 계정을 탈퇴할 수 있다")
+    void deleteMeByAnyRole(Role requesterRole) {
+        UserEntity user = createUser(USER_ID, requesterRole);
+        when(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).thenReturn(Optional.of(user));
+
+        userService.deleteMe(principal(USER_ID, requesterRole));
+
+        assertThat(user.isDeleted()).isTrue();
+        assertThat(user.getDeletedAt()).isNotNull();
+        assertThat(user.getDeletedBy()).isEqualTo("requester");
+    }
+
+    @Test
+    @DisplayName("본인 탈퇴 대상 사용자가 없으면 USER_NOT_FOUND로 처리한다")
+    void deleteMeWithMissingUser() {
+        when(userRepository.findByIdAndDeletedAtIsNull(USER_ID)).thenReturn(Optional.empty());
+
+        assertAppException(
+                () -> userService.deleteMe(principal(USER_ID, Role.CUSTOMER)),
+                AuthErrorCode.USER_NOT_FOUND
+        );
+    }
+}


### PR DESCRIPTION
Ref #41 

## 📄 작업 내용
본인 회원 탈퇴 API를 추가했습니다.

- `UserController`에 본인 회원 탈퇴 API를 추가했습니다.
  - `DELETE /api/v1/user`
  - 로그인한 사용자가 본인 계정을 탈퇴할 수 있습니다.
  - 성공 시 `200 OK`와 공통 `ApiResponse`를 반환합니다.

- `UserService`에 본인 회원 탈퇴 로직을 추가했습니다.
  - 로그인한 사용자의 ID로 삭제되지 않은 활성 사용자를 조회합니다.
  - 대상 사용자가 없으면 `USER_NOT_FOUND` 예외를 반환합니다.
  - `BaseEntity.markDeleted(...)`를 사용해 `deletedAt`, `deletedBy`를 기록합니다.
  - 실제 row를 삭제하지 않는 soft delete 방식으로 처리합니다.

- 본인 회원 탈퇴 서비스 테스트를 추가했습니다.
  - 모든 권한의 본인 탈퇴 성공 케이스 검증
  - 탈퇴 시 `deletedAt`, `deletedBy` 세팅 검증
  - 탈퇴 대상 사용자가 없는 경우 예외 처리 검증
