### PR TITLE
Issue #52 [FEAT] 운영 지역 삭제 API 구현

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/area/application/service/AreaService.java
+++ b/src/main/java/com/sparta/spartadelivery/area/application/service/AreaService.java
@@ -8,6 +8,7 @@ import com.sparta.spartadelivery.area.presentation.dto.response.AreaDetailRespon
 import com.sparta.spartadelivery.global.exception.AppException;
 import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
 import com.sparta.spartadelivery.user.domain.entity.Role;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -41,11 +42,31 @@ public class AreaService {
         return AreaDetailResponse.from(areaRepository.save(area));
     }
 
+    @Transactional
+    public void deleteArea(UUID areaId, UserPrincipal requester) {
+        // 운영 지역 삭제는 MASTER 권한만 허용한다.
+        validateDeletePermission(requester);
+
+        // 이미 삭제된 운영 지역은 삭제 대상으로 다루지 않는다.
+        Area area = areaRepository.findByIdAndDeletedAtIsNull(areaId)
+                .orElseThrow(() -> new AppException(AreaErrorCode.AREA_NOT_FOUND));
+
+        // 실제 row를 삭제하지 않고 감사 필드에 삭제 시각과 삭제자를 기록한다.
+        area.markDeleted(requester.getAccountName());
+    }
+
     private void validateCreatePermission(UserPrincipal requester) {
         if (requester.getRole() == Role.MANAGER || requester.getRole() == Role.MASTER) {
             return;
         }
         throw new AppException(AreaErrorCode.AREA_CREATE_ACCESS_DENIED);
+    }
+
+    private void validateDeletePermission(UserPrincipal requester) {
+        if (requester.getRole() == Role.MASTER) {
+            return;
+        }
+        throw new AppException(AreaErrorCode.AREA_DELETE_ACCESS_DENIED);
     }
 
     private void validateDuplicateName(String name) {

--- a/src/main/java/com/sparta/spartadelivery/area/domain/repository/AreaRepository.java
+++ b/src/main/java/com/sparta/spartadelivery/area/domain/repository/AreaRepository.java
@@ -1,10 +1,13 @@
 package com.sparta.spartadelivery.area.domain.repository;
 
 import com.sparta.spartadelivery.area.domain.entity.Area;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AreaRepository extends JpaRepository<Area, UUID> {
 
     boolean existsByNameAndDeletedAtIsNull(String name);
+
+    Optional<Area> findByIdAndDeletedAtIsNull(UUID id);
 }

--- a/src/main/java/com/sparta/spartadelivery/area/exception/AreaErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/area/exception/AreaErrorCode.java
@@ -6,9 +6,13 @@ import org.springframework.http.HttpStatus;
 
 @Getter
 public enum AreaErrorCode implements BaseErrorCode {
-
+    // 운영 지역 등록 API 관련 에러 코드
     AREA_CREATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "운영 지역을 등록할 권한이 없습니다."),
-    DUPLICATE_AREA_NAME(HttpStatus.BAD_REQUEST, "이미 등록된 운영 지역명입니다.");
+    DUPLICATE_AREA_NAME(HttpStatus.BAD_REQUEST, "이미 등록된 운영 지역명입니다."),
+
+    // 운영 지역 삭제 API 관련 에러 코드
+    AREA_DELETE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "운영 지역을 삭제할 권한이 없습니다."),
+    AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "운영 지역을 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/sparta/spartadelivery/area/presentation/controller/AreaController.java
+++ b/src/main/java/com/sparta/spartadelivery/area/presentation/controller/AreaController.java
@@ -8,10 +8,13 @@ import com.sparta.spartadelivery.global.presentation.dto.ApiResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -49,5 +52,29 @@ public class AreaController {
         AreaDetailResponse response = areaService.createArea(request, userPrincipal);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(HttpStatus.CREATED.value(), "CREATED", response));
+    }
+
+    @Operation(
+            summary = "운영 지역 삭제 API",
+            description = """
+                    운영 지역을 soft delete 방식으로 삭제 처리합니다.
+
+                    **요청 가능 권한**
+
+                    - MASTER
+
+                    **처리 정책**
+
+                    - 실제 데이터를 삭제하지 않고 deletedAt, deletedBy를 기록합니다.
+                    - 이미 삭제된 운영 지역은 삭제 대상으로 조회되지 않습니다.
+                    """
+    )
+    @DeleteMapping("/{areaId}")
+    public ResponseEntity<ApiResponse<Void>> deleteArea(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID areaId
+    ) {
+        areaService.deleteArea(areaId, userPrincipal);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), null));
     }
 }

--- a/src/test/java/com/sparta/spartadelivery/area/application/AreaServiceTest.java
+++ b/src/test/java/com/sparta/spartadelivery/area/application/AreaServiceTest.java
@@ -15,6 +15,7 @@ import com.sparta.spartadelivery.area.presentation.dto.request.AreaCreateRequest
 import com.sparta.spartadelivery.global.exception.AppException;
 import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
 import com.sparta.spartadelivery.user.domain.entity.Role;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -47,7 +48,7 @@ class AreaServiceTest {
             return area;
         });
 
-        // when: 운영 지역 등록 서비스를 호출한다.
+        // when
         var response = areaService.createArea(request, requester);
 
         // then: Area 엔티티가 저장되고 등록 결과가 응답으로 반환된다.
@@ -133,6 +134,75 @@ class AreaServiceTest {
                 .isEqualTo(AreaErrorCode.DUPLICATE_AREA_NAME);
 
         verify(areaRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("MASTER 권한 사용자는 운영 지역을 삭제할 수 있다")
+    void deleteAreaByMaster() {
+        // given: 삭제되지 않은 운영 지역과 MASTER 권한 요청자를 준비한다.
+        UUID areaId = UUID.randomUUID();
+        Area area = Area.builder()
+                .name("Gwanghwamun")
+                .city("Seoul")
+                .district("Jongno-gu")
+                .active(true)
+                .build();
+        UserPrincipal requester = principal(Role.MASTER);
+        when(areaRepository.findByIdAndDeletedAtIsNull(areaId)).thenReturn(Optional.of(area));
+
+        // when
+        areaService.deleteArea(areaId, requester);
+
+        // then: 삭제자와 삭제 시간이 기록된다.
+        assertThat(area.isDeleted()).isTrue();
+        assertThat(area.getDeletedBy()).isEqualTo("manager01");
+    }
+
+    @Test
+    @DisplayName("MANAGER 권한 사용자는 운영 지역을 삭제할 수 없다")
+    void deleteAreaByManagerDenied() {
+        // given: MANAGER 권한 요청자를 준비한다.
+        UUID areaId = UUID.randomUUID();
+        UserPrincipal requester = principal(Role.MANAGER);
+
+        // when & then: 권한 예외가 발생하고 운영 지역 조회는 수행되지 않는다.
+        assertThatThrownBy(() -> areaService.deleteArea(areaId, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(AreaErrorCode.AREA_DELETE_ACCESS_DENIED);
+
+        verify(areaRepository, never()).findByIdAndDeletedAtIsNull(any());
+    }
+
+    @Test
+    @DisplayName("CUSTOMER 권한 사용자는 운영 지역을 삭제할 수 없다")
+    void deleteAreaByCustomerDenied() {
+        // given: CUSTOMER 권한 요청자를 준비한다.
+        UUID areaId = UUID.randomUUID();
+        UserPrincipal requester = principal(Role.CUSTOMER);
+
+        // when & then: 권한 예외가 발생하고 운영 지역 조회는 수행되지 않는다.
+        assertThatThrownBy(() -> areaService.deleteArea(areaId, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(AreaErrorCode.AREA_DELETE_ACCESS_DENIED);
+
+        verify(areaRepository, never()).findByIdAndDeletedAtIsNull(any());
+    }
+
+    @Test
+    @DisplayName("삭제 대상 운영 지역이 없으면 삭제할 수 없다")
+    void deleteAreaNotFound() {
+        // given: areaId에 해당하는 미삭제 운영 지역이 없다.
+        UUID areaId = UUID.randomUUID();
+        UserPrincipal requester = principal(Role.MASTER);
+        when(areaRepository.findByIdAndDeletedAtIsNull(areaId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> areaService.deleteArea(areaId, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(AreaErrorCode.AREA_NOT_FOUND);
     }
 
     private UserPrincipal principal(Role role) {

--- a/src/test/java/com/sparta/spartadelivery/area/presentation/controller/AreaControllerTest.java
+++ b/src/test/java/com/sparta/spartadelivery/area/presentation/controller/AreaControllerTest.java
@@ -3,7 +3,9 @@ package com.sparta.spartadelivery.area.presentation.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -71,23 +73,13 @@ class AreaControllerTest {
     @MockitoBean
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
-    private UsernamePasswordAuthenticationToken authToken;
+    private UsernamePasswordAuthenticationToken managerToken;
+    private UsernamePasswordAuthenticationToken masterToken;
 
     @BeforeEach
     void setUp() throws Exception {
-        UserPrincipal userPrincipal = UserPrincipal.builder()
-                .id(1L)
-                .accountName("manager01")
-                .email("manager01@example.com")
-                .password("password")
-                .nickname("manager")
-                .role(Role.MANAGER)
-                .build();
-        authToken = new UsernamePasswordAuthenticationToken(
-                userPrincipal,
-                null,
-                userPrincipal.getAuthorities()
-        );
+        managerToken = authenticationToken(Role.MANAGER);
+        masterToken = authenticationToken(Role.MASTER);
 
         doAnswer(invocation -> {
             jakarta.servlet.FilterChain chain = invocation.getArgument(2);
@@ -97,7 +89,7 @@ class AreaControllerTest {
     }
 
     @Test
-    @DisplayName("Create area returns 201 CREATED")
+    @DisplayName("운영 지역 등록 성공 시 201 CREATED를 반환한다")
     void createArea() throws Exception {
         AreaCreateRequest request = new AreaCreateRequest("Gwanghwamun", "Seoul", "Jongno-gu", true);
         AreaDetailResponse response = new AreaDetailResponse(
@@ -111,7 +103,7 @@ class AreaControllerTest {
         given(areaService.createArea(any(AreaCreateRequest.class), any(UserPrincipal.class))).willReturn(response);
 
         mockMvc.perform(post("/api/v1/areas")
-                        .with(authentication(authToken))
+                        .with(authentication(managerToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
@@ -124,30 +116,84 @@ class AreaControllerTest {
     }
 
     @Test
-    @DisplayName("Create area with duplicate name returns 400")
+    @DisplayName("운영 지역명이 중복되면 400을 반환한다")
     void createAreaWithDuplicateName() throws Exception {
         AreaCreateRequest request = new AreaCreateRequest("Gwanghwamun", "Seoul", "Jongno-gu", true);
         given(areaService.createArea(any(AreaCreateRequest.class), any(UserPrincipal.class)))
                 .willThrow(new AppException(AreaErrorCode.DUPLICATE_AREA_NAME));
 
         mockMvc.perform(post("/api/v1/areas")
-                        .with(authentication(authToken))
+                        .with(authentication(managerToken))
                         .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)))
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("이미 등록된 운영 지역명입니다."));
     }
 
     @Test
-    @DisplayName("Create area with invalid request returns 400")
+    @DisplayName("운영 지역 등록 요청값이 유효하지 않으면 400을 반환한다")
     void createAreaWithInvalidRequest() throws Exception {
         AreaCreateRequest request = new AreaCreateRequest("", "Seoul", "Jongno-gu", true);
 
         mockMvc.perform(post("/api/v1/areas")
-                        .with(authentication(authToken))
+                        .with(authentication(managerToken))
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isBadRequest())
                 .andExpect(jsonPath("$.message").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    @DisplayName("운영 지역 삭제 성공 시 200 OK를 반환한다")
+    void deleteArea() throws Exception {
+        UUID areaId = UUID.randomUUID();
+
+        mockMvc.perform(delete("/api/v1/areas/{areaId}", areaId)
+                        .with(authentication(masterToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("운영 지역 삭제 권한이 없으면 403을 반환한다")
+    void deleteAreaAccessDenied() throws Exception {
+        UUID areaId = UUID.randomUUID();
+        doThrow(new AppException(AreaErrorCode.AREA_DELETE_ACCESS_DENIED))
+                .when(areaService).deleteArea(any(UUID.class), any(UserPrincipal.class));
+
+        mockMvc.perform(delete("/api/v1/areas/{areaId}", areaId)
+                        .with(authentication(managerToken)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("운영 지역을 삭제할 권한이 없습니다."));
+    }
+
+    @Test
+    @DisplayName("삭제할 운영 지역이 없으면 404를 반환한다")
+    void deleteAreaNotFound() throws Exception {
+        UUID areaId = UUID.randomUUID();
+        doThrow(new AppException(AreaErrorCode.AREA_NOT_FOUND))
+                .when(areaService).deleteArea(any(UUID.class), any(UserPrincipal.class));
+
+        mockMvc.perform(delete("/api/v1/areas/{areaId}", areaId)
+                        .with(authentication(masterToken)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("운영 지역을 찾을 수 없습니다."));
+    }
+
+    private UsernamePasswordAuthenticationToken authenticationToken(Role role) {
+        UserPrincipal userPrincipal = UserPrincipal.builder()
+                .id(1L)
+                .accountName("manager01")
+                .email("manager01@example.com")
+                .password("password")
+                .nickname("manager")
+                .role(role)
+                .build();
+        return new UsernamePasswordAuthenticationToken(
+                userPrincipal,
+                null,
+                userPrincipal.getAuthorities()
+        );
     }
 }


### PR DESCRIPTION
Ref #52 

## 작업 내용
- 운영 지역 삭제 API 구현
  - `DELETE /api/v1/areas/{areaId}`
  - 삭제 권한: `MASTER`
  - 삭제 방식: soft delete
- 운영 지역 삭제 서비스 로직 추가
  - 미삭제 운영 지역만 삭제 대상으로 조회
  - 대상이 없으면 404 예외 반환
  - `BaseEntity.markDeleted`로 `deletedAt`, `deletedBy` 기록
- 운영 지역 삭제 관련 에러 코드 추가
  - 삭제 권한 없음
  - 운영 지역 없음
- 운영 지역 삭제 Swagger 명세 추가
- 운영 지역 삭제 서비스/컨트롤러 테스트 추가

## 권한 정책
- `MASTER`: 운영 지역 삭제 가능
- `MANAGER`, `CUSTOMER`, `OWNER`: 운영 지역 삭제 불가

## 테스트
```powershell
.\gradlew.bat test --tests com.sparta.spartadelivery.area.*