### PR TITLE
Issue #54 [FEAT] 운영 지역 수정 API 구현

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/area/application/service/AreaService.java
+++ b/src/main/java/com/sparta/spartadelivery/area/application/service/AreaService.java
@@ -4,6 +4,7 @@ import com.sparta.spartadelivery.area.domain.entity.Area;
 import com.sparta.spartadelivery.area.domain.repository.AreaRepository;
 import com.sparta.spartadelivery.area.exception.AreaErrorCode;
 import com.sparta.spartadelivery.area.presentation.dto.request.AreaCreateRequest;
+import com.sparta.spartadelivery.area.presentation.dto.request.AreaUpdateRequest;
 import com.sparta.spartadelivery.area.presentation.dto.response.AreaDetailResponse;
 import com.sparta.spartadelivery.global.exception.AppException;
 import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
@@ -43,16 +44,40 @@ public class AreaService {
     }
 
     @Transactional
+    public AreaDetailResponse updateArea(UUID areaId, AreaUpdateRequest request, UserPrincipal requester) {
+        // 운영 지역 수정은 MANAGER, MASTER 권한만 허용한다.
+        validateUpdatePermission(requester);
+
+        Area area = getActiveArea(areaId);
+
+        String name = request.name().strip();
+        String city = request.city().strip();
+        String district = request.district().strip();
+
+        // 지역명이 실제로 변경되는 경우에만 중복 검증을 수행한다.
+        if (!area.getName().equals(name)) {
+            validateDuplicateName(name);
+        }
+
+        area.update(name, city, district, request.active());
+        return AreaDetailResponse.from(area);
+    }
+
+    @Transactional
     public void deleteArea(UUID areaId, UserPrincipal requester) {
         // 운영 지역 삭제는 MASTER 권한만 허용한다.
         validateDeletePermission(requester);
 
         // 이미 삭제된 운영 지역은 삭제 대상으로 다루지 않는다.
-        Area area = areaRepository.findByIdAndDeletedAtIsNull(areaId)
-                .orElseThrow(() -> new AppException(AreaErrorCode.AREA_NOT_FOUND));
+        Area area = getActiveArea(areaId);
 
         // 실제 row를 삭제하지 않고 감사 필드에 삭제 시각과 삭제자를 기록한다.
         area.markDeleted(requester.getAccountName());
+    }
+
+    private Area getActiveArea(UUID areaId) {
+        return areaRepository.findByIdAndDeletedAtIsNull(areaId)
+                .orElseThrow(() -> new AppException(AreaErrorCode.AREA_NOT_FOUND));
     }
 
     private void validateCreatePermission(UserPrincipal requester) {
@@ -60,6 +85,13 @@ public class AreaService {
             return;
         }
         throw new AppException(AreaErrorCode.AREA_CREATE_ACCESS_DENIED);
+    }
+
+    private void validateUpdatePermission(UserPrincipal requester) {
+        if (requester.getRole() == Role.MANAGER || requester.getRole() == Role.MASTER) {
+            return;
+        }
+        throw new AppException(AreaErrorCode.AREA_UPDATE_ACCESS_DENIED);
     }
 
     private void validateDeletePermission(UserPrincipal requester) {

--- a/src/main/java/com/sparta/spartadelivery/area/exception/AreaErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/area/exception/AreaErrorCode.java
@@ -10,6 +10,9 @@ public enum AreaErrorCode implements BaseErrorCode {
     AREA_CREATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "운영 지역을 등록할 권한이 없습니다."),
     DUPLICATE_AREA_NAME(HttpStatus.BAD_REQUEST, "이미 등록된 운영 지역명입니다."),
 
+    // 운영 지역 수정 API 관련 에러 코드
+    AREA_UPDATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "운영 지역을 수정할 권한이 없습니다."),
+
     // 운영 지역 삭제 API 관련 에러 코드
     AREA_DELETE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "운영 지역을 삭제할 권한이 없습니다."),
     AREA_NOT_FOUND(HttpStatus.NOT_FOUND, "운영 지역을 찾을 수 없습니다.");

--- a/src/main/java/com/sparta/spartadelivery/area/presentation/controller/AreaController.java
+++ b/src/main/java/com/sparta/spartadelivery/area/presentation/controller/AreaController.java
@@ -2,6 +2,7 @@ package com.sparta.spartadelivery.area.presentation.controller;
 
 import com.sparta.spartadelivery.area.application.service.AreaService;
 import com.sparta.spartadelivery.area.presentation.dto.request.AreaCreateRequest;
+import com.sparta.spartadelivery.area.presentation.dto.request.AreaUpdateRequest;
 import com.sparta.spartadelivery.area.presentation.dto.response.AreaDetailResponse;
 import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
 import com.sparta.spartadelivery.global.presentation.dto.ApiResponse;
@@ -16,6 +17,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -52,6 +54,32 @@ public class AreaController {
         AreaDetailResponse response = areaService.createArea(request, userPrincipal);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(HttpStatus.CREATED.value(), "CREATED", response));
+    }
+
+    @Operation(
+            summary = "운영 지역 수정 API",
+            description = """
+                    운영 지역 정보를 수정합니다.
+
+                    **요청 가능 권한**
+
+                    - MANAGER
+                    - MASTER
+
+                    **처리 정책**
+
+                    - 삭제되지 않은 운영 지역만 수정할 수 있습니다.
+                    - 지역명이 변경되는 경우 삭제되지 않은 운영 지역 기준으로 중복 검증을 수행합니다.
+                    """
+    )
+    @PutMapping("/{areaId}")
+    public ResponseEntity<ApiResponse<AreaDetailResponse>> updateArea(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID areaId,
+            @Valid @RequestBody AreaUpdateRequest request
+    ) {
+        AreaDetailResponse response = areaService.updateArea(areaId, request, userPrincipal);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), response));
     }
 
     @Operation(

--- a/src/main/java/com/sparta/spartadelivery/area/presentation/dto/request/AreaUpdateRequest.java
+++ b/src/main/java/com/sparta/spartadelivery/area/presentation/dto/request/AreaUpdateRequest.java
@@ -1,0 +1,28 @@
+package com.sparta.spartadelivery.area.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+public record AreaUpdateRequest(
+        @Schema(description = "운영 지역명", example = "광화문")
+        @NotBlank(message = "지역명은 필수입니다.")
+        @Size(max = 100, message = "지역명은 최대 100자까지 입력할 수 있습니다.")
+        String name,
+
+        @Schema(description = "시/도", example = "서울특별시")
+        @NotBlank(message = "시/도는 필수입니다.")
+        @Size(max = 50, message = "시/도는 최대 50자까지 입력할 수 있습니다.")
+        String city,
+
+        @Schema(description = "구/군", example = "종로구")
+        @NotBlank(message = "구/군은 필수입니다.")
+        @Size(max = 50, message = "구/군은 최대 50자까지 입력할 수 있습니다.")
+        String district,
+
+        @Schema(description = "운영 지역 활성화 여부", example = "true")
+        @NotNull(message = "활성화 여부는 필수입니다.")
+        Boolean active
+) {
+}

--- a/src/test/java/com/sparta/spartadelivery/area/application/AreaServiceTest.java
+++ b/src/test/java/com/sparta/spartadelivery/area/application/AreaServiceTest.java
@@ -12,6 +12,7 @@ import com.sparta.spartadelivery.area.domain.entity.Area;
 import com.sparta.spartadelivery.area.domain.repository.AreaRepository;
 import com.sparta.spartadelivery.area.exception.AreaErrorCode;
 import com.sparta.spartadelivery.area.presentation.dto.request.AreaCreateRequest;
+import com.sparta.spartadelivery.area.presentation.dto.request.AreaUpdateRequest;
 import com.sparta.spartadelivery.global.exception.AppException;
 import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
 import com.sparta.spartadelivery.user.domain.entity.Role;
@@ -137,16 +138,159 @@ class AreaServiceTest {
     }
 
     @Test
+    @DisplayName("MANAGER 권한 사용자는 운영 지역을 수정할 수 있다")
+    void updateAreaByManager() {
+        // given: 수정 대상 운영 지역과 MANAGER 권한 요청자를 준비한다.
+        UUID areaId = UUID.randomUUID();
+        Area area = area("Gwanghwamun", "Seoul", "Jongno-gu", true);
+        AreaUpdateRequest request = new AreaUpdateRequest("Jongno", "Seoul", "Jongno-gu", false);
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(areaRepository.findByIdAndDeletedAtIsNull(areaId)).thenReturn(Optional.of(area));
+        when(areaRepository.existsByNameAndDeletedAtIsNull("Jongno")).thenReturn(false);
+
+        // when
+        var response = areaService.updateArea(areaId, request, requester);
+
+        // then: 요청값으로 운영 지역 정보가 수정된다.
+        assertThat(area.getName()).isEqualTo("Jongno");
+        assertThat(area.getCity()).isEqualTo("Seoul");
+        assertThat(area.getDistrict()).isEqualTo("Jongno-gu");
+        assertThat(area.isActive()).isFalse();
+        assertThat(response.name()).isEqualTo("Jongno");
+        assertThat(response.active()).isFalse();
+    }
+
+    @Test
+    @DisplayName("MASTER 권한 사용자는 운영 지역을 수정할 수 있다")
+    void updateAreaByMaster() {
+        // given
+        UUID areaId = UUID.randomUUID();
+        Area area = area("Gwanghwamun", "Seoul", "Jongno-gu", true);
+        AreaUpdateRequest request = new AreaUpdateRequest("Jongno", "Seoul", "Jongno-gu", true);
+        UserPrincipal requester = principal(Role.MASTER);
+        when(areaRepository.findByIdAndDeletedAtIsNull(areaId)).thenReturn(Optional.of(area));
+        when(areaRepository.existsByNameAndDeletedAtIsNull("Jongno")).thenReturn(false);
+
+        // when
+        var response = areaService.updateArea(areaId, request, requester);
+
+        // then
+        assertThat(response.name()).isEqualTo("Jongno");
+    }
+
+    @Test
+    @DisplayName("운영 지역 수정 요청값은 저장 전에 앞뒤 공백이 제거된다")
+    void updateAreaWithTrimmedValues() {
+        // given
+        UUID areaId = UUID.randomUUID();
+        Area area = area("Gwanghwamun", "Seoul", "Jongno-gu", true);
+        AreaUpdateRequest request = new AreaUpdateRequest(" Jongno ", " Seoul-si ", " Jongno-gu ", true);
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(areaRepository.findByIdAndDeletedAtIsNull(areaId)).thenReturn(Optional.of(area));
+        when(areaRepository.existsByNameAndDeletedAtIsNull("Jongno")).thenReturn(false);
+
+        // when
+        areaService.updateArea(areaId, request, requester);
+
+        // then
+        assertThat(area.getName()).isEqualTo("Jongno");
+        assertThat(area.getCity()).isEqualTo("Seoul-si");
+        assertThat(area.getDistrict()).isEqualTo("Jongno-gu");
+    }
+
+    @Test
+    @DisplayName("운영 지역명이 변경되지 않으면 중복 검증 없이 수정할 수 있다")
+    void updateAreaWithSameNameSkipsDuplicateCheck() {
+        // given
+        UUID areaId = UUID.randomUUID();
+        Area area = area("Gwanghwamun", "Seoul", "Jongno-gu", true);
+        AreaUpdateRequest request = new AreaUpdateRequest("Gwanghwamun", "Seoul-si", "Jongno-gu", false);
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(areaRepository.findByIdAndDeletedAtIsNull(areaId)).thenReturn(Optional.of(area));
+
+        // when
+        areaService.updateArea(areaId, request, requester);
+
+        // then
+        verify(areaRepository, never()).existsByNameAndDeletedAtIsNull(any());
+        assertThat(area.getCity()).isEqualTo("Seoul-si");
+        assertThat(area.isActive()).isFalse();
+    }
+
+    @Test
+    @DisplayName("CUSTOMER 권한 사용자는 운영 지역을 수정할 수 없다")
+    void updateAreaByCustomerDenied() {
+        // given
+        UUID areaId = UUID.randomUUID();
+        AreaUpdateRequest request = new AreaUpdateRequest("Jongno", "Seoul", "Jongno-gu", true);
+        UserPrincipal requester = principal(Role.CUSTOMER);
+
+        // when & then
+        assertThatThrownBy(() -> areaService.updateArea(areaId, request, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(AreaErrorCode.AREA_UPDATE_ACCESS_DENIED);
+
+        verify(areaRepository, never()).findByIdAndDeletedAtIsNull(any());
+    }
+
+    @Test
+    @DisplayName("OWNER 권한 사용자는 운영 지역을 수정할 수 없다")
+    void updateAreaByOwnerDenied() {
+        // given
+        UUID areaId = UUID.randomUUID();
+        AreaUpdateRequest request = new AreaUpdateRequest("Jongno", "Seoul", "Jongno-gu", true);
+        UserPrincipal requester = principal(Role.OWNER);
+
+        // when & then
+        assertThatThrownBy(() -> areaService.updateArea(areaId, request, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(AreaErrorCode.AREA_UPDATE_ACCESS_DENIED);
+
+        verify(areaRepository, never()).findByIdAndDeletedAtIsNull(any());
+    }
+
+    @Test
+    @DisplayName("수정 대상 운영 지역이 없으면 수정할 수 없다")
+    void updateAreaNotFound() {
+        // given
+        UUID areaId = UUID.randomUUID();
+        AreaUpdateRequest request = new AreaUpdateRequest("Jongno", "Seoul", "Jongno-gu", true);
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(areaRepository.findByIdAndDeletedAtIsNull(areaId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> areaService.updateArea(areaId, request, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(AreaErrorCode.AREA_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("변경하려는 운영 지역명이 중복되면 수정할 수 없다")
+    void updateAreaWithDuplicateName() {
+        // given
+        UUID areaId = UUID.randomUUID();
+        Area area = area("Gwanghwamun", "Seoul", "Jongno-gu", true);
+        AreaUpdateRequest request = new AreaUpdateRequest("Jongno", "Seoul", "Jongno-gu", true);
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(areaRepository.findByIdAndDeletedAtIsNull(areaId)).thenReturn(Optional.of(area));
+        when(areaRepository.existsByNameAndDeletedAtIsNull("Jongno")).thenReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> areaService.updateArea(areaId, request, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(AreaErrorCode.DUPLICATE_AREA_NAME);
+    }
+
+    @Test
     @DisplayName("MASTER 권한 사용자는 운영 지역을 삭제할 수 있다")
     void deleteAreaByMaster() {
         // given: 삭제되지 않은 운영 지역과 MASTER 권한 요청자를 준비한다.
         UUID areaId = UUID.randomUUID();
-        Area area = Area.builder()
-                .name("Gwanghwamun")
-                .city("Seoul")
-                .district("Jongno-gu")
-                .active(true)
-                .build();
+        Area area = area("Gwanghwamun", "Seoul", "Jongno-gu", true);
         UserPrincipal requester = principal(Role.MASTER);
         when(areaRepository.findByIdAndDeletedAtIsNull(areaId)).thenReturn(Optional.of(area));
 
@@ -203,6 +347,15 @@ class AreaServiceTest {
                 .isInstanceOf(AppException.class)
                 .extracting("errorCode")
                 .isEqualTo(AreaErrorCode.AREA_NOT_FOUND);
+    }
+
+    private Area area(String name, String city, String district, boolean active) {
+        return Area.builder()
+                .name(name)
+                .city(city)
+                .district(district)
+                .active(active)
+                .build();
     }
 
     private UserPrincipal principal(Role role) {

--- a/src/test/java/com/sparta/spartadelivery/area/presentation/controller/AreaControllerTest.java
+++ b/src/test/java/com/sparta/spartadelivery/area/presentation/controller/AreaControllerTest.java
@@ -7,6 +7,7 @@ import static org.mockito.Mockito.doThrow;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -14,6 +15,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.sparta.spartadelivery.area.application.service.AreaService;
 import com.sparta.spartadelivery.area.exception.AreaErrorCode;
 import com.sparta.spartadelivery.area.presentation.dto.request.AreaCreateRequest;
+import com.sparta.spartadelivery.area.presentation.dto.request.AreaUpdateRequest;
 import com.sparta.spartadelivery.area.presentation.dto.response.AreaDetailResponse;
 import com.sparta.spartadelivery.global.exception.AppException;
 import com.sparta.spartadelivery.global.infrastructure.config.security.JwtAuthenticationFilter;
@@ -92,14 +94,7 @@ class AreaControllerTest {
     @DisplayName("운영 지역 등록 성공 시 201 CREATED를 반환한다")
     void createArea() throws Exception {
         AreaCreateRequest request = new AreaCreateRequest("Gwanghwamun", "Seoul", "Jongno-gu", true);
-        AreaDetailResponse response = new AreaDetailResponse(
-                UUID.randomUUID(),
-                "Gwanghwamun",
-                "Seoul",
-                "Jongno-gu",
-                true,
-                LocalDateTime.now()
-        );
+        AreaDetailResponse response = areaResponse("Gwanghwamun", "Seoul", "Jongno-gu", true);
         given(areaService.createArea(any(AreaCreateRequest.class), any(UserPrincipal.class))).willReturn(response);
 
         mockMvc.perform(post("/api/v1/areas")
@@ -144,6 +139,72 @@ class AreaControllerTest {
     }
 
     @Test
+    @DisplayName("운영 지역 수정 성공 시 200 OK를 반환한다")
+    void updateArea() throws Exception {
+        UUID areaId = UUID.randomUUID();
+        AreaUpdateRequest request = new AreaUpdateRequest("Jongno", "Seoul", "Jongno-gu", false);
+        AreaDetailResponse response = areaResponse("Jongno", "Seoul", "Jongno-gu", false);
+        given(areaService.updateArea(any(UUID.class), any(AreaUpdateRequest.class), any(UserPrincipal.class)))
+                .willReturn(response);
+
+        mockMvc.perform(put("/api/v1/areas/{areaId}", areaId)
+                        .with(authentication(managerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.name").value("Jongno"))
+                .andExpect(jsonPath("$.data.active").value(false));
+    }
+
+    @Test
+    @DisplayName("운영 지역 수정 요청값이 유효하지 않으면 400을 반환한다")
+    void updateAreaWithInvalidRequest() throws Exception {
+        UUID areaId = UUID.randomUUID();
+        AreaUpdateRequest request = new AreaUpdateRequest("", "Seoul", "Jongno-gu", true);
+
+        mockMvc.perform(put("/api/v1/areas/{areaId}", areaId)
+                        .with(authentication(managerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    @DisplayName("운영 지역 수정 권한이 없으면 403을 반환한다")
+    void updateAreaAccessDenied() throws Exception {
+        UUID areaId = UUID.randomUUID();
+        AreaUpdateRequest request = new AreaUpdateRequest("Jongno", "Seoul", "Jongno-gu", true);
+        given(areaService.updateArea(any(UUID.class), any(AreaUpdateRequest.class), any(UserPrincipal.class)))
+                .willThrow(new AppException(AreaErrorCode.AREA_UPDATE_ACCESS_DENIED));
+
+        mockMvc.perform(put("/api/v1/areas/{areaId}", areaId)
+                        .with(authentication(managerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("운영 지역을 수정할 권한이 없습니다."));
+    }
+
+    @Test
+    @DisplayName("수정할 운영 지역이 없으면 404를 반환한다")
+    void updateAreaNotFound() throws Exception {
+        UUID areaId = UUID.randomUUID();
+        AreaUpdateRequest request = new AreaUpdateRequest("Jongno", "Seoul", "Jongno-gu", true);
+        given(areaService.updateArea(any(UUID.class), any(AreaUpdateRequest.class), any(UserPrincipal.class)))
+                .willThrow(new AppException(AreaErrorCode.AREA_NOT_FOUND));
+
+        mockMvc.perform(put("/api/v1/areas/{areaId}", areaId)
+                        .with(authentication(managerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("운영 지역을 찾을 수 없습니다."));
+    }
+
+    @Test
     @DisplayName("운영 지역 삭제 성공 시 200 OK를 반환한다")
     void deleteArea() throws Exception {
         UUID areaId = UUID.randomUUID();
@@ -179,6 +240,17 @@ class AreaControllerTest {
                         .with(authentication(masterToken)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.message").value("운영 지역을 찾을 수 없습니다."));
+    }
+
+    private AreaDetailResponse areaResponse(String name, String city, String district, boolean active) {
+        return new AreaDetailResponse(
+                UUID.randomUUID(),
+                name,
+                city,
+                district,
+                active,
+                LocalDateTime.now()
+        );
     }
 
     private UsernamePasswordAuthenticationToken authenticationToken(Role role) {


### PR DESCRIPTION
Ref #54 

## 작업 내용
- 운영 지역 수정 API 구현
  - `PUT /api/v1/areas/{areaId}`
  - 수정 권한: `MANAGER`, `MASTER`
  - 수정 성공 시 `200 OK` 응답
- 운영 지역 수정 요청 DTO 추가
  - `AreaUpdateRequest`
  - `name`, `city`, `district`, `active` validation 적용
- 운영 지역 수정 서비스 로직 추가
  - 미삭제 운영 지역만 수정 대상으로 조회
  - 대상이 없으면 404 예외 반환
  - `name`, `city`, `district` 앞뒤 공백 제거 후 저장
  - 지역명이 변경되는 경우에만 중복 검증 수행
- 운영 지역 수정 관련 에러 코드 추가
  - 수정 권한 없음
- 운영 지역 수정 Swagger 명세 추가
- 운영 지역 수정 서비스/컨트롤러 테스트 추가

## 권한 정책
- `MANAGER`, `MASTER`: 운영 지역 수정 가능
- `CUSTOMER`, `OWNER`: 운영 지역 수정 불가

## 테스트
```powershell
.\gradlew.bat test --tests com.sparta.spartadelivery.area.*




참고
• 삭제된 운영 지역은 수정 대상으로 조회되지 않습니다.
• 기존 지역명과 동일한 이름으로 수정하는 경우에는 중복 검증을 생략합니다.
• 기존 지역명과 다른 이름으로 변경하는 경우, 미삭제 운영 지역 기준으로 중복 여부를 검증합니다.