### PR TITLE
Issue #64 Category 도메인을 StoreCategory로 리팩토링

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/category/domain/repository/CategoryRepository.java
+++ b/src/main/java/com/sparta/spartadelivery/category/domain/repository/CategoryRepository.java
@@ -1,8 +1,0 @@
-package com.sparta.spartadelivery.category.domain.repository;
-
-import com.sparta.spartadelivery.category.domain.entity.Category;
-import java.util.UUID;
-import org.springframework.data.jpa.repository.JpaRepository;
-
-public interface CategoryRepository extends JpaRepository<Category, UUID> {
-}

--- a/src/main/java/com/sparta/spartadelivery/store/domain/entity/Store.java
+++ b/src/main/java/com/sparta/spartadelivery/store/domain/entity/Store.java
@@ -1,8 +1,8 @@
 package com.sparta.spartadelivery.store.domain.entity;
 
 import com.sparta.spartadelivery.area.domain.entity.Area;
-import com.sparta.spartadelivery.category.domain.entity.Category;
 import com.sparta.spartadelivery.global.entity.BaseEntity;
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
 import com.sparta.spartadelivery.user.domain.entity.UserEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -36,8 +36,8 @@ public class Store extends BaseEntity {
     private UserEntity owner;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "category_id", nullable = false)
-    private Category category;
+    @JoinColumn(name = "store_category_id", nullable = false)
+    private StoreCategory storeCategory;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "area_id", nullable = false)
@@ -61,22 +61,22 @@ public class Store extends BaseEntity {
     @Builder
     private Store(
             UserEntity owner,
-            Category category,
+            StoreCategory storeCategory,
             Area area,
             String name,
             String address,
             String phone
     ) {
         this.owner = owner;
-        this.category = category;
+        this.storeCategory = storeCategory;
         this.area = area;
         this.name = name;
         this.address = address;
         this.phone = phone;
     }
 
-    public void update(Category category, Area area, String name, String address, String phone) {
-        this.category = category;
+    public void update(StoreCategory storeCategory, Area area, String name, String address, String phone) {
+        this.storeCategory = storeCategory;
         this.area = area;
         this.name = name;
         this.address = address;

--- a/src/main/java/com/sparta/spartadelivery/storecategory/domain/entity/StoreCategory.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/domain/entity/StoreCategory.java
@@ -1,4 +1,4 @@
-package com.sparta.spartadelivery.category.domain.entity;
+package com.sparta.spartadelivery.storecategory.domain.entity;
 
 import com.sparta.spartadelivery.global.entity.BaseEntity;
 import jakarta.persistence.Column;
@@ -15,20 +15,20 @@ import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
-@Table(name = "p_category")
+@Table(name = "p_store_category")
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-public class Category extends BaseEntity {
+public class StoreCategory extends BaseEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.UUID)
-    @Column(name = "category_id")
+    @Column(name = "store_category_id")
     private UUID id;
 
     @Column(name = "name", length = 50, nullable = false, unique = true)
     private String name;
 
     @Builder
-    private Category(String name) {
+    private StoreCategory(String name) {
         this.name = name;
     }
 

--- a/src/main/java/com/sparta/spartadelivery/storecategory/domain/repository/StoreCategoryRepository.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/domain/repository/StoreCategoryRepository.java
@@ -1,0 +1,8 @@
+package com.sparta.spartadelivery.storecategory.domain.repository;
+
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import java.util.UUID;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StoreCategoryRepository extends JpaRepository<StoreCategory, UUID> {
+}


### PR DESCRIPTION
Ref #64 

## 작업 내용
- 기존 `Category` 도메인을 `StoreCategory` 도메인으로 리네이밍했습니다.
- `CategoryRepository`를 `StoreCategoryRepository`로 변경했습니다.
- `Store` 엔티티의 카테고리 연관관계를 `storeCategory` 기준으로 정리했습니다.
- 테이블명과 조인 컬럼명도 `StoreCategory` 기준으로 맞췄습니다.

## 주요 변경 사항
- 엔티티
  - `Category` -> `StoreCategory`
- Repository
  - `CategoryRepository` -> `StoreCategoryRepository`
- 패키지
  - `category` -> `storecategory`
- 테이블 / 컬럼
  - `p_category` -> `p_store_category`
  - `category_id` -> `store_category_id`
- Store 연관관계
  - `Store.category` -> `Store.storeCategory`

## 변경 이유
- 현재 `Category` 도메인은 실제로 가게(Store)가 참조하는 카테고리 역할을 하고 있습니다.
- 이후 메뉴 카테고리(`MenuCategory`) 도메인을 별도로 분리하기 위해, 현재 도메인의 의미를 `StoreCategory`로 명확히 정리할 필요가 있었습니다.
- 이번 리네이밍으로 가게 카테고리와 메뉴 카테고리의 책임을 분리할 수 있는 기반을 마련했습니다.

## 테스트
- `.\gradlew.bat compileJava`

## 체크리스트
- [x] Category 도메인 리네이밍
- [x] Repository 리네이밍
- [x] Store 연관관계 필드명 정리
- [x] 테이블명 및 조인 컬럼명 정리
- [x] 컴파일 확인