### PR TITLE
Issue #66 가게 카테고리 등록 API 구현 

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/storecategory/application/service/StoreCategoryService.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/application/service/StoreCategoryService.java
@@ -1,0 +1,51 @@
+package com.sparta.spartadelivery.storecategory.application.service;
+
+import com.sparta.spartadelivery.global.exception.AppException;
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import com.sparta.spartadelivery.storecategory.domain.repository.StoreCategoryRepository;
+import com.sparta.spartadelivery.storecategory.exception.StoreCategoryErrorCode;
+import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
+import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryDetailResponse;
+import com.sparta.spartadelivery.user.domain.entity.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoreCategoryService {
+
+    private final StoreCategoryRepository storeCategoryRepository;
+
+    @Transactional
+    public StoreCategoryDetailResponse createStoreCategory(
+            StoreCategoryCreateRequest request,
+            UserPrincipal requester
+    ) {
+        validateCreatePermission(requester);
+
+        String name = request.name().strip();
+        validateDuplicateName(name);
+
+        StoreCategory storeCategory = StoreCategory.builder()
+                .name(name)
+                .build();
+
+        return StoreCategoryDetailResponse.from(storeCategoryRepository.save(storeCategory));
+    }
+
+    private void validateCreatePermission(UserPrincipal requester) {
+        if (requester.getRole() == Role.MANAGER || requester.getRole() == Role.MASTER) {
+            return;
+        }
+        throw new AppException(StoreCategoryErrorCode.STORE_CATEGORY_CREATE_ACCESS_DENIED);
+    }
+
+    private void validateDuplicateName(String name) {
+        if (storeCategoryRepository.existsByNameAndDeletedAtIsNull(name)) {
+            throw new AppException(StoreCategoryErrorCode.DUPLICATE_STORE_CATEGORY_NAME);
+        }
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/storecategory/domain/repository/StoreCategoryRepository.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/domain/repository/StoreCategoryRepository.java
@@ -5,4 +5,6 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreCategoryRepository extends JpaRepository<StoreCategory, UUID> {
+
+    boolean existsByNameAndDeletedAtIsNull(String name);
 }

--- a/src/main/java/com/sparta/spartadelivery/storecategory/exception/StoreCategoryErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/exception/StoreCategoryErrorCode.java
@@ -1,0 +1,20 @@
+package com.sparta.spartadelivery.storecategory.exception;
+
+import com.sparta.spartadelivery.global.exception.BaseErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum StoreCategoryErrorCode implements BaseErrorCode {
+    // 가게 카테고리 등록 API 관련 에러 코드
+    STORE_CATEGORY_CREATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "가게 카테고리를 등록할 권한이 없습니다."),
+    DUPLICATE_STORE_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "이미 등록된 가게 카테고리명입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    StoreCategoryErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryController.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryController.java
@@ -1,0 +1,52 @@
+package com.sparta.spartadelivery.storecategory.presentation.controller;
+
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.global.presentation.dto.ApiResponse;
+import com.sparta.spartadelivery.storecategory.application.service.StoreCategoryService;
+import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
+import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/store-categories")
+@RequiredArgsConstructor
+@Tag(name = "StoreCategory", description = "가게 카테고리 관리 API")
+public class StoreCategoryController {
+
+    private final StoreCategoryService storeCategoryService;
+
+    @Operation(
+            summary = "가게 카테고리 등록 API",
+            description = """
+                    새로운 가게 카테고리를 등록합니다.
+
+                    **요청 가능 권한**
+
+                    - MANAGER
+                    - MASTER
+
+                    **처리 정책**
+
+                    - 삭제되지 않은 가게 카테고리 중 같은 이름이 있으면 등록할 수 없습니다.
+                    """
+    )
+    @PostMapping
+    public ResponseEntity<ApiResponse<StoreCategoryDetailResponse>> createStoreCategory(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody StoreCategoryCreateRequest request
+    ) {
+        StoreCategoryDetailResponse response = storeCategoryService.createStoreCategory(request, userPrincipal);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(HttpStatus.CREATED.value(), "CREATED", response));
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/storecategory/presentation/dto/request/StoreCategoryCreateRequest.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/presentation/dto/request/StoreCategoryCreateRequest.java
@@ -1,0 +1,13 @@
+package com.sparta.spartadelivery.storecategory.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record StoreCategoryCreateRequest(
+        @Schema(description = "가게 카테고리명", example = "한식")
+        @NotBlank(message = "가게 카테고리명은 필수입니다.")
+        @Size(max = 50, message = "가게 카테고리명은 최대 50자까지 입력할 수 있습니다.")
+        String name
+) {
+}

--- a/src/main/java/com/sparta/spartadelivery/storecategory/presentation/dto/response/StoreCategoryDetailResponse.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/presentation/dto/response/StoreCategoryDetailResponse.java
@@ -1,0 +1,26 @@
+package com.sparta.spartadelivery.storecategory.presentation.dto.response;
+
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record StoreCategoryDetailResponse(
+        @Schema(description = "가게 카테고리 ID", example = "550e8400-e29b-41d4-a716-446655440010")
+        UUID id,
+
+        @Schema(description = "가게 카테고리명", example = "한식")
+        String name,
+
+        @Schema(description = "가게 카테고리 생성 일시", example = "2026-04-22T12:00:00")
+        LocalDateTime createdAt
+) {
+
+    public static StoreCategoryDetailResponse from(StoreCategory storeCategory) {
+        return new StoreCategoryDetailResponse(
+                storeCategory.getId(),
+                storeCategory.getName(),
+                storeCategory.getCreatedAt()
+        );
+    }
+}

--- a/src/test/java/com/sparta/spartadelivery/storecategory/application/StoreCategoryServiceTest.java
+++ b/src/test/java/com/sparta/spartadelivery/storecategory/application/StoreCategoryServiceTest.java
@@ -1,0 +1,128 @@
+package com.sparta.spartadelivery.storecategory.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sparta.spartadelivery.global.exception.AppException;
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.storecategory.application.service.StoreCategoryService;
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import com.sparta.spartadelivery.storecategory.domain.repository.StoreCategoryRepository;
+import com.sparta.spartadelivery.storecategory.exception.StoreCategoryErrorCode;
+import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
+import com.sparta.spartadelivery.user.domain.entity.Role;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class StoreCategoryServiceTest {
+
+    @Mock
+    private StoreCategoryRepository storeCategoryRepository;
+
+    @InjectMocks
+    private StoreCategoryService storeCategoryService;
+
+    @Test
+    @DisplayName("MANAGER 권한 사용자는 가게 카테고리를 등록할 수 있다")
+    void createStoreCategoryByManager() {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest("한식");
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("한식")).thenReturn(false);
+        when(storeCategoryRepository.save(any(StoreCategory.class))).thenAnswer(invocation -> {
+            StoreCategory storeCategory = invocation.getArgument(0);
+            ReflectionTestUtils.setField(storeCategory, "id", UUID.randomUUID());
+            return storeCategory;
+        });
+
+        var response = storeCategoryService.createStoreCategory(request, requester);
+
+        ArgumentCaptor<StoreCategory> captor = ArgumentCaptor.forClass(StoreCategory.class);
+        verify(storeCategoryRepository).save(captor.capture());
+        assertThat(captor.getValue().getName()).isEqualTo("한식");
+        assertThat(response.id()).isNotNull();
+        assertThat(response.name()).isEqualTo("한식");
+    }
+
+    @Test
+    @DisplayName("MASTER 권한 사용자는 가게 카테고리를 등록할 수 있다")
+    void createStoreCategoryByMaster() {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest("치킨");
+        UserPrincipal requester = principal(Role.MASTER);
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("치킨")).thenReturn(false);
+        when(storeCategoryRepository.save(any(StoreCategory.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = storeCategoryService.createStoreCategory(request, requester);
+
+        verify(storeCategoryRepository).save(any(StoreCategory.class));
+        assertThat(response.name()).isEqualTo("치킨");
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 등록 요청값은 저장 전에 앞뒤 공백을 제거한다")
+    void createStoreCategoryWithTrimmedName() {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest(" 한식 ");
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("한식")).thenReturn(false);
+        when(storeCategoryRepository.save(any(StoreCategory.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        storeCategoryService.createStoreCategory(request, requester);
+
+        ArgumentCaptor<StoreCategory> captor = ArgumentCaptor.forClass(StoreCategory.class);
+        verify(storeCategoryRepository).existsByNameAndDeletedAtIsNull("한식");
+        verify(storeCategoryRepository).save(captor.capture());
+        assertThat(captor.getValue().getName()).isEqualTo("한식");
+    }
+
+    @Test
+    @DisplayName("CUSTOMER 권한 사용자는 가게 카테고리를 등록할 수 없다")
+    void createStoreCategoryByCustomerDenied() {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest("한식");
+        UserPrincipal requester = principal(Role.CUSTOMER);
+
+        assertThatThrownBy(() -> storeCategoryService.createStoreCategory(request, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_CREATE_ACCESS_DENIED);
+
+        verify(storeCategoryRepository, never()).existsByNameAndDeletedAtIsNull(any());
+        verify(storeCategoryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("삭제되지 않은 가게 카테고리명이 중복되면 등록할 수 없다")
+    void createStoreCategoryWithDuplicateName() {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest("한식");
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("한식")).thenReturn(true);
+
+        assertThatThrownBy(() -> storeCategoryService.createStoreCategory(request, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.DUPLICATE_STORE_CATEGORY_NAME);
+
+        verify(storeCategoryRepository, never()).save(any());
+    }
+
+    private UserPrincipal principal(Role role) {
+        return UserPrincipal.builder()
+                .id(1L)
+                .accountName("manager01")
+                .email("manager01@example.com")
+                .password("password")
+                .nickname("manager")
+                .role(role)
+                .build();
+    }
+}

--- a/src/test/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryControllerTest.java
+++ b/src/test/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryControllerTest.java
@@ -1,0 +1,156 @@
+package com.sparta.spartadelivery.storecategory.presentation.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.spartadelivery.global.exception.AppException;
+import com.sparta.spartadelivery.global.infrastructure.config.security.JwtAuthenticationFilter;
+import com.sparta.spartadelivery.global.infrastructure.config.security.JwtTokenProvider;
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.storecategory.application.service.StoreCategoryService;
+import com.sparta.spartadelivery.storecategory.exception.StoreCategoryErrorCode;
+import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
+import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryDetailResponse;
+import com.sparta.spartadelivery.user.domain.entity.Role;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(StoreCategoryController.class)
+@Import(StoreCategoryControllerTest.TestSecurityConfig.class)
+class StoreCategoryControllerTest {
+
+    @TestConfiguration
+    @EnableWebSecurity
+    static class TestSecurityConfig {
+        @Bean
+        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+            http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .securityContext(context -> context.requireExplicitSave(false));
+            return http.build();
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private StoreCategoryService storeCategoryService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    private UsernamePasswordAuthenticationToken managerToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        managerToken = authenticationToken(Role.MANAGER);
+
+        doAnswer(invocation -> {
+            jakarta.servlet.FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 등록 성공 시 201 CREATED를 반환한다")
+    void createStoreCategory() throws Exception {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest("한식");
+        StoreCategoryDetailResponse response = storeCategoryResponse("한식");
+        given(storeCategoryService.createStoreCategory(any(StoreCategoryCreateRequest.class), any(UserPrincipal.class)))
+                .willReturn(response);
+
+        mockMvc.perform(post("/api/v1/store-categories")
+                        .with(authentication(managerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.message").value("CREATED"))
+                .andExpect(jsonPath("$.data.name").value("한식"));
+    }
+
+    @Test
+    @DisplayName("가게 카테고리명이 중복되면 400을 반환한다")
+    void createStoreCategoryWithDuplicateName() throws Exception {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest("한식");
+        given(storeCategoryService.createStoreCategory(any(StoreCategoryCreateRequest.class), any(UserPrincipal.class)))
+                .willThrow(new AppException(StoreCategoryErrorCode.DUPLICATE_STORE_CATEGORY_NAME));
+
+        mockMvc.perform(post("/api/v1/store-categories")
+                        .with(authentication(managerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("이미 등록된 가게 카테고리명입니다."));
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 등록 요청값이 유효하지 않으면 400을 반환한다")
+    void createStoreCategoryWithInvalidRequest() throws Exception {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest("");
+
+        mockMvc.perform(post("/api/v1/store-categories")
+                        .with(authentication(managerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("VALIDATION_ERROR"));
+    }
+
+    private StoreCategoryDetailResponse storeCategoryResponse(String name) {
+        return new StoreCategoryDetailResponse(
+                UUID.randomUUID(),
+                name,
+                LocalDateTime.now()
+        );
+    }
+
+    private UsernamePasswordAuthenticationToken authenticationToken(Role role) {
+        UserPrincipal userPrincipal = UserPrincipal.builder()
+                .id(1L)
+                .accountName("manager01")
+                .email("manager01@example.com")
+                .password("password")
+                .nickname("manager")
+                .role(role)
+                .build();
+        return new UsernamePasswordAuthenticationToken(
+                userPrincipal,
+                null,
+                userPrincipal.getAuthorities()
+        );
+    }
+}


### PR DESCRIPTION
Ref #66 

## 작업 내용
- 가게 카테고리 등록 관련 ErrorCode를 추가했습니다.
- 가게 카테고리 등록 요청/응답 DTO를 추가했습니다.
- 삭제되지 않은 가게 카테고리명 중복 검증용 Repository 메서드를 추가했습니다.
- 가게 카테고리 등록 서비스 로직을 구현했습니다.
- `POST /api/v1/store-categories` API를 추가했습니다.
- Swagger 명세를 추가했습니다.
- 서비스 테스트와 컨트롤러 테스트를 작성했습니다.

## 주요 변경 사항
- `StoreCategoryErrorCode`
  - 등록 권한 예외
  - 이름 중복 예외
- `StoreCategoryCreateRequest`
- `StoreCategoryDetailResponse`
- `StoreCategoryRepository`
  - `existsByNameAndDeletedAtIsNull(String name)` 추가
- `StoreCategoryService`
  - `createStoreCategory(...)` 구현
- `StoreCategoryController`
  - `POST /api/v1/store-categories` 추가

## 처리 내용
- MANAGER, MASTER 권한만 등록 가능하도록 검증했습니다.
- 삭제되지 않은 가게 카테고리 기준으로 이름 중복을 검증했습니다.
- 요청값의 앞뒤 공백을 제거한 뒤 저장하도록 처리했습니다.
- 공통 `ApiResponse` 형식으로 `201 CREATED` 응답을 반환하도록 구현했습니다.

## 테스트
- `.\gradlew.bat test --tests com.sparta.spartadelivery.storecategory.*`

## 체크리스트
- [x] 가게 카테고리 등록 API 구현
- [x] 중복 검증 로직 추가
- [x] Swagger 명세 추가
- [x] Service Test 작성
- [x] Controller Test 작성
- [x] StoreCategory 테스트 검증 완료