### PR TITLE
Issue #68 가게 카테고리 목록 조회 API 구현 

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/storecategory/application/service/StoreCategoryService.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/application/service/StoreCategoryService.java
@@ -7,8 +7,13 @@ import com.sparta.spartadelivery.storecategory.domain.repository.StoreCategoryRe
 import com.sparta.spartadelivery.storecategory.exception.StoreCategoryErrorCode;
 import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
 import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryDetailResponse;
+import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryPageResponse;
 import com.sparta.spartadelivery.user.domain.entity.Role;
+import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,6 +21,14 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
 public class StoreCategoryService {
+
+    private static final Set<Integer> ALLOWED_PAGE_SIZES = Set.of(10, 30, 50);
+    private static final Set<String> ALLOWED_SORT_PROPERTIES = Set.of(
+            "name",
+            "createdAt",
+            "updatedAt"
+    );
+    private static final String DEFAULT_SORT = "createdAt,DESC";
 
     private final StoreCategoryRepository storeCategoryRepository;
 
@@ -36,6 +49,15 @@ public class StoreCategoryService {
         return StoreCategoryDetailResponse.from(storeCategoryRepository.save(storeCategory));
     }
 
+    public StoreCategoryPageResponse getStoreCategories(int page, int size, String sort) {
+        String normalizedSort = normalizeSort(sort);
+        Pageable pageable = createPageable(page, size, normalizedSort);
+        return StoreCategoryPageResponse.from(
+                storeCategoryRepository.findAllByDeletedAtIsNull(pageable),
+                normalizedSort
+        );
+    }
+
     private void validateCreatePermission(UserPrincipal requester) {
         if (requester.getRole() == Role.MANAGER || requester.getRole() == Role.MASTER) {
             return;
@@ -47,5 +69,40 @@ public class StoreCategoryService {
         if (storeCategoryRepository.existsByNameAndDeletedAtIsNull(name)) {
             throw new AppException(StoreCategoryErrorCode.DUPLICATE_STORE_CATEGORY_NAME);
         }
+    }
+
+    private String normalizeSort(String sort) {
+        if (sort == null || sort.isBlank()) {
+            return DEFAULT_SORT;
+        }
+
+        String[] parts = sort.split(",");
+        if (parts.length != 2) {
+            throw new AppException(StoreCategoryErrorCode.STORE_CATEGORY_LIST_INVALID_SORT_FORMAT);
+        }
+
+        String property = parts[0].trim();
+        String direction = parts[1].trim().toUpperCase();
+
+        if (!ALLOWED_SORT_PROPERTIES.contains(property)) {
+            throw new AppException(StoreCategoryErrorCode.STORE_CATEGORY_LIST_UNSUPPORTED_SORT_PROPERTY);
+        }
+        if (!direction.equals("ASC") && !direction.equals("DESC")) {
+            throw new AppException(StoreCategoryErrorCode.STORE_CATEGORY_LIST_UNSUPPORTED_SORT_DIRECTION);
+        }
+
+        return property + "," + direction;
+    }
+
+    private Pageable createPageable(int page, int size, String sort) {
+        if (page < 0) {
+            throw new AppException(StoreCategoryErrorCode.STORE_CATEGORY_LIST_INVALID_PAGE_NUMBER);
+        }
+        if (!ALLOWED_PAGE_SIZES.contains(size)) {
+            throw new AppException(StoreCategoryErrorCode.STORE_CATEGORY_LIST_INVALID_PAGE_SIZE);
+        }
+
+        String[] parts = sort.split(",");
+        return PageRequest.of(page, size, Sort.by(Sort.Direction.fromString(parts[1]), parts[0]));
     }
 }

--- a/src/main/java/com/sparta/spartadelivery/storecategory/application/service/StoreCategoryService.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/application/service/StoreCategoryService.java
@@ -1,0 +1,51 @@
+package com.sparta.spartadelivery.storecategory.application.service;
+
+import com.sparta.spartadelivery.global.exception.AppException;
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import com.sparta.spartadelivery.storecategory.domain.repository.StoreCategoryRepository;
+import com.sparta.spartadelivery.storecategory.exception.StoreCategoryErrorCode;
+import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
+import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryDetailResponse;
+import com.sparta.spartadelivery.user.domain.entity.Role;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoreCategoryService {
+
+    private final StoreCategoryRepository storeCategoryRepository;
+
+    @Transactional
+    public StoreCategoryDetailResponse createStoreCategory(
+            StoreCategoryCreateRequest request,
+            UserPrincipal requester
+    ) {
+        validateCreatePermission(requester);
+
+        String name = request.name().strip();
+        validateDuplicateName(name);
+
+        StoreCategory storeCategory = StoreCategory.builder()
+                .name(name)
+                .build();
+
+        return StoreCategoryDetailResponse.from(storeCategoryRepository.save(storeCategory));
+    }
+
+    private void validateCreatePermission(UserPrincipal requester) {
+        if (requester.getRole() == Role.MANAGER || requester.getRole() == Role.MASTER) {
+            return;
+        }
+        throw new AppException(StoreCategoryErrorCode.STORE_CATEGORY_CREATE_ACCESS_DENIED);
+    }
+
+    private void validateDuplicateName(String name) {
+        if (storeCategoryRepository.existsByNameAndDeletedAtIsNull(name)) {
+            throw new AppException(StoreCategoryErrorCode.DUPLICATE_STORE_CATEGORY_NAME);
+        }
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/storecategory/domain/repository/StoreCategoryRepository.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/domain/repository/StoreCategoryRepository.java
@@ -2,9 +2,13 @@ package com.sparta.spartadelivery.storecategory.domain.repository;
 
 import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
 import java.util.UUID;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreCategoryRepository extends JpaRepository<StoreCategory, UUID> {
 
     boolean existsByNameAndDeletedAtIsNull(String name);
+
+    Page<StoreCategory> findAllByDeletedAtIsNull(Pageable pageable);
 }

--- a/src/main/java/com/sparta/spartadelivery/storecategory/domain/repository/StoreCategoryRepository.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/domain/repository/StoreCategoryRepository.java
@@ -5,4 +5,6 @@ import java.util.UUID;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StoreCategoryRepository extends JpaRepository<StoreCategory, UUID> {
+
+    boolean existsByNameAndDeletedAtIsNull(String name);
 }

--- a/src/main/java/com/sparta/spartadelivery/storecategory/exception/StoreCategoryErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/exception/StoreCategoryErrorCode.java
@@ -8,7 +8,14 @@ import org.springframework.http.HttpStatus;
 public enum StoreCategoryErrorCode implements BaseErrorCode {
     // 가게 카테고리 등록 API 관련 에러 코드
     STORE_CATEGORY_CREATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "가게 카테고리를 등록할 권한이 없습니다."),
-    DUPLICATE_STORE_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "이미 등록된 가게 카테고리명입니다.");
+    DUPLICATE_STORE_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "이미 등록된 가게 카테고리명입니다."),
+
+    // 가게 카테고리 목록 조회 API 관련 에러 코드
+    STORE_CATEGORY_LIST_INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST, "페이지 번호는 0 이상이어야 합니다."),
+    STORE_CATEGORY_LIST_INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "페이지 크기는 10, 30, 50 중 하나여야 합니다."),
+    STORE_CATEGORY_LIST_INVALID_SORT_FORMAT(HttpStatus.BAD_REQUEST, "정렬 조건은 {property},{direction} 형식이어야 합니다."),
+    STORE_CATEGORY_LIST_UNSUPPORTED_SORT_PROPERTY(HttpStatus.BAD_REQUEST, "지원하지 않는 정렬 필드입니다."),
+    STORE_CATEGORY_LIST_UNSUPPORTED_SORT_DIRECTION(HttpStatus.BAD_REQUEST, "정렬 방향은 ASC 또는 DESC만 사용할 수 있습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/sparta/spartadelivery/storecategory/exception/StoreCategoryErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/exception/StoreCategoryErrorCode.java
@@ -1,0 +1,20 @@
+package com.sparta.spartadelivery.storecategory.exception;
+
+import com.sparta.spartadelivery.global.exception.BaseErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum StoreCategoryErrorCode implements BaseErrorCode {
+    // 가게 카테고리 등록 API 관련 에러 코드
+    STORE_CATEGORY_CREATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "가게 카테고리를 등록할 권한이 없습니다."),
+    DUPLICATE_STORE_CATEGORY_NAME(HttpStatus.BAD_REQUEST, "이미 등록된 가게 카테고리명입니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    StoreCategoryErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryController.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryController.java
@@ -5,16 +5,20 @@ import com.sparta.spartadelivery.global.presentation.dto.ApiResponse;
 import com.sparta.spartadelivery.storecategory.application.service.StoreCategoryService;
 import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
 import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryDetailResponse;
+import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -48,5 +52,41 @@ public class StoreCategoryController {
         StoreCategoryDetailResponse response = storeCategoryService.createStoreCategory(request, userPrincipal);
         return ResponseEntity.status(HttpStatus.CREATED)
                 .body(ApiResponse.success(HttpStatus.CREATED.value(), "CREATED", response));
+    }
+
+    @Operation(
+            summary = "가게 카테고리 목록 조회 API",
+            description = """
+                    가게 카테고리 목록을 페이지네이션으로 조회합니다.
+
+                    **요청 가능 권한**
+
+                    - ALL
+
+                    **처리 정책**
+
+                    - 삭제되지 않은 가게 카테고리만 조회할 수 있습니다.
+                    - 기본 정렬은 createdAt,DESC 입니다.
+                    - size는 10, 30, 50 중 하나만 사용할 수 있습니다.
+                    - sort는 `{필드명},{정렬방향}` 형식으로 전달합니다.
+                    - 정렬 가능 필드: `name`, `createdAt`, `updatedAt`
+                    - 정렬 방향: `ASC`, `DESC`
+                    - 예시: `name,ASC`, `createdAt,DESC`
+                    """
+    )
+    @GetMapping
+    public ResponseEntity<ApiResponse<StoreCategoryPageResponse>> getStoreCategories(
+            @Parameter(description = "페이지 번호", example = "0")
+            @RequestParam(defaultValue = "0") int page,
+            @Parameter(description = "페이지 크기 (허용값: 10, 30, 50)", example = "10")
+            @RequestParam(defaultValue = "10") int size,
+            @Parameter(
+                    description = "정렬 조건 (`{필드명},{정렬방향}` 형식, 허용 필드: name, createdAt, updatedAt / 방향: ASC, DESC)",
+                    example = "createdAt,DESC"
+            )
+            @RequestParam(required = false) String sort
+    ) {
+        StoreCategoryPageResponse response = storeCategoryService.getStoreCategories(page, size, sort);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), response));
     }
 }

--- a/src/main/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryController.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryController.java
@@ -1,0 +1,52 @@
+package com.sparta.spartadelivery.storecategory.presentation.controller;
+
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.global.presentation.dto.ApiResponse;
+import com.sparta.spartadelivery.storecategory.application.service.StoreCategoryService;
+import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
+import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/store-categories")
+@RequiredArgsConstructor
+@Tag(name = "StoreCategory", description = "가게 카테고리 관리 API")
+public class StoreCategoryController {
+
+    private final StoreCategoryService storeCategoryService;
+
+    @Operation(
+            summary = "가게 카테고리 등록 API",
+            description = """
+                    새로운 가게 카테고리를 등록합니다.
+
+                    **요청 가능 권한**
+
+                    - MANAGER
+                    - MASTER
+
+                    **처리 정책**
+
+                    - 삭제되지 않은 가게 카테고리 중 같은 이름이 있으면 등록할 수 없습니다.
+                    """
+    )
+    @PostMapping
+    public ResponseEntity<ApiResponse<StoreCategoryDetailResponse>> createStoreCategory(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody StoreCategoryCreateRequest request
+    ) {
+        StoreCategoryDetailResponse response = storeCategoryService.createStoreCategory(request, userPrincipal);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(HttpStatus.CREATED.value(), "CREATED", response));
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/storecategory/presentation/dto/request/StoreCategoryCreateRequest.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/presentation/dto/request/StoreCategoryCreateRequest.java
@@ -1,0 +1,13 @@
+package com.sparta.spartadelivery.storecategory.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record StoreCategoryCreateRequest(
+        @Schema(description = "가게 카테고리명", example = "한식")
+        @NotBlank(message = "가게 카테고리명은 필수입니다.")
+        @Size(max = 50, message = "가게 카테고리명은 최대 50자까지 입력할 수 있습니다.")
+        String name
+) {
+}

--- a/src/main/java/com/sparta/spartadelivery/storecategory/presentation/dto/response/StoreCategoryDetailResponse.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/presentation/dto/response/StoreCategoryDetailResponse.java
@@ -1,0 +1,26 @@
+package com.sparta.spartadelivery.storecategory.presentation.dto.response;
+
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record StoreCategoryDetailResponse(
+        @Schema(description = "가게 카테고리 ID", example = "550e8400-e29b-41d4-a716-446655440010")
+        UUID id,
+
+        @Schema(description = "가게 카테고리명", example = "한식")
+        String name,
+
+        @Schema(description = "가게 카테고리 생성 일시", example = "2026-04-22T12:00:00")
+        LocalDateTime createdAt
+) {
+
+    public static StoreCategoryDetailResponse from(StoreCategory storeCategory) {
+        return new StoreCategoryDetailResponse(
+                storeCategory.getId(),
+                storeCategory.getName(),
+                storeCategory.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/storecategory/presentation/dto/response/StoreCategoryListResponse.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/presentation/dto/response/StoreCategoryListResponse.java
@@ -1,0 +1,26 @@
+package com.sparta.spartadelivery.storecategory.presentation.dto.response;
+
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record StoreCategoryListResponse(
+        @Schema(description = "가게 카테고리 ID", example = "550e8400-e29b-41d4-a716-446655440010")
+        UUID id,
+
+        @Schema(description = "가게 카테고리명", example = "한식")
+        String name,
+
+        @Schema(description = "가게 카테고리 생성 일시", example = "2026-04-22T12:00:00")
+        LocalDateTime createdAt
+) {
+
+    public static StoreCategoryListResponse from(StoreCategory storeCategory) {
+        return new StoreCategoryListResponse(
+                storeCategory.getId(),
+                storeCategory.getName(),
+                storeCategory.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/storecategory/presentation/dto/response/StoreCategoryPageResponse.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/presentation/dto/response/StoreCategoryPageResponse.java
@@ -1,0 +1,40 @@
+package com.sparta.spartadelivery.storecategory.presentation.dto.response;
+
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record StoreCategoryPageResponse(
+        @Schema(description = "가게 카테고리 목록")
+        List<StoreCategoryListResponse> content,
+
+        @Schema(description = "현재 페이지 번호", example = "0")
+        int page,
+
+        @Schema(description = "페이지 크기", example = "10")
+        int size,
+
+        @Schema(description = "전체 요소 수", example = "12")
+        long totalElements,
+
+        @Schema(description = "전체 페이지 수", example = "2")
+        int totalPages,
+
+        @Schema(description = "정렬 조건", example = "createdAt,DESC")
+        String sort
+) {
+
+    public static StoreCategoryPageResponse from(Page<StoreCategory> storeCategories, String sort) {
+        return new StoreCategoryPageResponse(
+                storeCategories.getContent().stream()
+                        .map(StoreCategoryListResponse::from)
+                        .toList(),
+                storeCategories.getNumber(),
+                storeCategories.getSize(),
+                storeCategories.getTotalElements(),
+                storeCategories.getTotalPages(),
+                sort
+        );
+    }
+}

--- a/src/test/java/com/sparta/spartadelivery/storecategory/application/StoreCategoryServiceTest.java
+++ b/src/test/java/com/sparta/spartadelivery/storecategory/application/StoreCategoryServiceTest.java
@@ -1,0 +1,128 @@
+package com.sparta.spartadelivery.storecategory.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sparta.spartadelivery.global.exception.AppException;
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.storecategory.application.service.StoreCategoryService;
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import com.sparta.spartadelivery.storecategory.domain.repository.StoreCategoryRepository;
+import com.sparta.spartadelivery.storecategory.exception.StoreCategoryErrorCode;
+import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
+import com.sparta.spartadelivery.user.domain.entity.Role;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class StoreCategoryServiceTest {
+
+    @Mock
+    private StoreCategoryRepository storeCategoryRepository;
+
+    @InjectMocks
+    private StoreCategoryService storeCategoryService;
+
+    @Test
+    @DisplayName("MANAGER 권한 사용자는 가게 카테고리를 등록할 수 있다")
+    void createStoreCategoryByManager() {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest("한식");
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("한식")).thenReturn(false);
+        when(storeCategoryRepository.save(any(StoreCategory.class))).thenAnswer(invocation -> {
+            StoreCategory storeCategory = invocation.getArgument(0);
+            ReflectionTestUtils.setField(storeCategory, "id", UUID.randomUUID());
+            return storeCategory;
+        });
+
+        var response = storeCategoryService.createStoreCategory(request, requester);
+
+        ArgumentCaptor<StoreCategory> captor = ArgumentCaptor.forClass(StoreCategory.class);
+        verify(storeCategoryRepository).save(captor.capture());
+        assertThat(captor.getValue().getName()).isEqualTo("한식");
+        assertThat(response.id()).isNotNull();
+        assertThat(response.name()).isEqualTo("한식");
+    }
+
+    @Test
+    @DisplayName("MASTER 권한 사용자는 가게 카테고리를 등록할 수 있다")
+    void createStoreCategoryByMaster() {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest("치킨");
+        UserPrincipal requester = principal(Role.MASTER);
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("치킨")).thenReturn(false);
+        when(storeCategoryRepository.save(any(StoreCategory.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = storeCategoryService.createStoreCategory(request, requester);
+
+        verify(storeCategoryRepository).save(any(StoreCategory.class));
+        assertThat(response.name()).isEqualTo("치킨");
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 등록 요청값은 저장 전에 앞뒤 공백을 제거한다")
+    void createStoreCategoryWithTrimmedName() {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest(" 한식 ");
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("한식")).thenReturn(false);
+        when(storeCategoryRepository.save(any(StoreCategory.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        storeCategoryService.createStoreCategory(request, requester);
+
+        ArgumentCaptor<StoreCategory> captor = ArgumentCaptor.forClass(StoreCategory.class);
+        verify(storeCategoryRepository).existsByNameAndDeletedAtIsNull("한식");
+        verify(storeCategoryRepository).save(captor.capture());
+        assertThat(captor.getValue().getName()).isEqualTo("한식");
+    }
+
+    @Test
+    @DisplayName("CUSTOMER 권한 사용자는 가게 카테고리를 등록할 수 없다")
+    void createStoreCategoryByCustomerDenied() {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest("한식");
+        UserPrincipal requester = principal(Role.CUSTOMER);
+
+        assertThatThrownBy(() -> storeCategoryService.createStoreCategory(request, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_CREATE_ACCESS_DENIED);
+
+        verify(storeCategoryRepository, never()).existsByNameAndDeletedAtIsNull(any());
+        verify(storeCategoryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("삭제되지 않은 가게 카테고리명이 중복되면 등록할 수 없다")
+    void createStoreCategoryWithDuplicateName() {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest("한식");
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("한식")).thenReturn(true);
+
+        assertThatThrownBy(() -> storeCategoryService.createStoreCategory(request, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.DUPLICATE_STORE_CATEGORY_NAME);
+
+        verify(storeCategoryRepository, never()).save(any());
+    }
+
+    private UserPrincipal principal(Role role) {
+        return UserPrincipal.builder()
+                .id(1L)
+                .accountName("manager01")
+                .email("manager01@example.com")
+                .password("password")
+                .nickname("manager")
+                .role(role)
+                .build();
+    }
+}

--- a/src/test/java/com/sparta/spartadelivery/storecategory/application/StoreCategoryServiceTest.java
+++ b/src/test/java/com/sparta/spartadelivery/storecategory/application/StoreCategoryServiceTest.java
@@ -15,6 +15,7 @@ import com.sparta.spartadelivery.storecategory.domain.repository.StoreCategoryRe
 import com.sparta.spartadelivery.storecategory.exception.StoreCategoryErrorCode;
 import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
 import com.sparta.spartadelivery.user.domain.entity.Role;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -23,6 +24,9 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -113,6 +117,91 @@ class StoreCategoryServiceTest {
                 .isEqualTo(StoreCategoryErrorCode.DUPLICATE_STORE_CATEGORY_NAME);
 
         verify(storeCategoryRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 목록을 페이지네이션으로 조회할 수 있다")
+    void getStoreCategories() {
+        StoreCategory first = storeCategory("한식");
+        StoreCategory second = storeCategory("치킨");
+        PageRequest pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        when(storeCategoryRepository.findAllByDeletedAtIsNull(pageable))
+                .thenReturn(new PageImpl<>(List.of(first, second), pageable, 2));
+
+        var response = storeCategoryService.getStoreCategories(0, 10, null);
+
+        assertThat(response.content()).hasSize(2);
+        assertThat(response.content().get(0).name()).isEqualTo("한식");
+        assertThat(response.content().get(1).name()).isEqualTo("치킨");
+        assertThat(response.page()).isEqualTo(0);
+        assertThat(response.size()).isEqualTo(10);
+        assertThat(response.totalElements()).isEqualTo(2);
+        assertThat(response.sort()).isEqualTo("createdAt,DESC");
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 목록 조회 결과가 없으면 빈 목록을 반환한다")
+    void getStoreCategoriesWithEmptyContent() {
+        PageRequest pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
+        when(storeCategoryRepository.findAllByDeletedAtIsNull(pageable))
+                .thenReturn(new PageImpl<>(List.of(), pageable, 0));
+
+        var response = storeCategoryService.getStoreCategories(0, 10, null);
+
+        assertThat(response.content()).isEmpty();
+        assertThat(response.totalElements()).isZero();
+        assertThat(response.totalPages()).isZero();
+    }
+
+    @Test
+    @DisplayName("페이지 번호가 0보다 작으면 가게 카테고리 목록을 조회할 수 없다")
+    void getStoreCategoriesWithInvalidPageNumber() {
+        assertThatThrownBy(() -> storeCategoryService.getStoreCategories(-1, 10, null))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_LIST_INVALID_PAGE_NUMBER);
+    }
+
+    @Test
+    @DisplayName("페이지 크기가 허용 범위를 벗어나면 가게 카테고리 목록을 조회할 수 없다")
+    void getStoreCategoriesWithInvalidPageSize() {
+        assertThatThrownBy(() -> storeCategoryService.getStoreCategories(0, 20, null))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_LIST_INVALID_PAGE_SIZE);
+    }
+
+    @Test
+    @DisplayName("정렬 조건 형식이 올바르지 않으면 가게 카테고리 목록을 조회할 수 없다")
+    void getStoreCategoriesWithInvalidSortFormat() {
+        assertThatThrownBy(() -> storeCategoryService.getStoreCategories(0, 10, "createdAt"))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_LIST_INVALID_SORT_FORMAT);
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 정렬 필드면 가게 카테고리 목록을 조회할 수 없다")
+    void getStoreCategoriesWithUnsupportedSortProperty() {
+        assertThatThrownBy(() -> storeCategoryService.getStoreCategories(0, 10, "id,DESC"))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_LIST_UNSUPPORTED_SORT_PROPERTY);
+    }
+
+    @Test
+    @DisplayName("지원하지 않는 정렬 방향이면 가게 카테고리 목록을 조회할 수 없다")
+    void getStoreCategoriesWithUnsupportedSortDirection() {
+        assertThatThrownBy(() -> storeCategoryService.getStoreCategories(0, 10, "createdAt,DOWN"))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_LIST_UNSUPPORTED_SORT_DIRECTION);
+    }
+
+    private StoreCategory storeCategory(String name) {
+        return StoreCategory.builder()
+                .name(name)
+                .build();
     }
 
     private UserPrincipal principal(Role role) {

--- a/src/test/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryControllerTest.java
+++ b/src/test/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryControllerTest.java
@@ -4,6 +4,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -17,8 +18,11 @@ import com.sparta.spartadelivery.storecategory.application.service.StoreCategory
 import com.sparta.spartadelivery.storecategory.exception.StoreCategoryErrorCode;
 import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
 import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryDetailResponse;
+import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryListResponse;
+import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryPageResponse;
 import com.sparta.spartadelivery.user.domain.entity.Role;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -130,8 +134,59 @@ class StoreCategoryControllerTest {
                 .andExpect(jsonPath("$.message").value("VALIDATION_ERROR"));
     }
 
+    @Test
+    @DisplayName("가게 카테고리 목록 조회 성공 시 200 OK를 반환한다")
+    void getStoreCategories() throws Exception {
+        StoreCategoryPageResponse response = new StoreCategoryPageResponse(
+                List.of(
+                        storeCategoryListResponse("한식"),
+                        storeCategoryListResponse("치킨")
+                ),
+                0,
+                10,
+                2,
+                1,
+                "createdAt,DESC"
+        );
+        given(storeCategoryService.getStoreCategories(0, 10, null)).willReturn(response);
+
+        mockMvc.perform(get("/api/v1/store-categories")
+                        .with(authentication(managerToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.content.length()").value(2))
+                .andExpect(jsonPath("$.data.content[0].name").value("한식"))
+                .andExpect(jsonPath("$.data.content[1].name").value("치킨"))
+                .andExpect(jsonPath("$.data.page").value(0))
+                .andExpect(jsonPath("$.data.size").value(10))
+                .andExpect(jsonPath("$.data.totalElements").value(2))
+                .andExpect(jsonPath("$.data.sort").value("createdAt,DESC"));
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 목록 조회 시 잘못된 페이지 번호면 400을 반환한다")
+    void getStoreCategoriesWithInvalidPageNumber() throws Exception {
+        given(storeCategoryService.getStoreCategories(-1, 10, null))
+                .willThrow(new AppException(StoreCategoryErrorCode.STORE_CATEGORY_LIST_INVALID_PAGE_NUMBER));
+
+        mockMvc.perform(get("/api/v1/store-categories")
+                        .with(authentication(managerToken))
+                        .param("page", "-1"))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("페이지 번호는 0 이상이어야 합니다."));
+    }
+
     private StoreCategoryDetailResponse storeCategoryResponse(String name) {
         return new StoreCategoryDetailResponse(
+                UUID.randomUUID(),
+                name,
+                LocalDateTime.now()
+        );
+    }
+
+    private StoreCategoryListResponse storeCategoryListResponse(String name) {
+        return new StoreCategoryListResponse(
                 UUID.randomUUID(),
                 name,
                 LocalDateTime.now()

--- a/src/test/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryControllerTest.java
+++ b/src/test/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryControllerTest.java
@@ -1,0 +1,156 @@
+package com.sparta.spartadelivery.storecategory.presentation.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.spartadelivery.global.exception.AppException;
+import com.sparta.spartadelivery.global.infrastructure.config.security.JwtAuthenticationFilter;
+import com.sparta.spartadelivery.global.infrastructure.config.security.JwtTokenProvider;
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.storecategory.application.service.StoreCategoryService;
+import com.sparta.spartadelivery.storecategory.exception.StoreCategoryErrorCode;
+import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
+import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryDetailResponse;
+import com.sparta.spartadelivery.user.domain.entity.Role;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(StoreCategoryController.class)
+@Import(StoreCategoryControllerTest.TestSecurityConfig.class)
+class StoreCategoryControllerTest {
+
+    @TestConfiguration
+    @EnableWebSecurity
+    static class TestSecurityConfig {
+        @Bean
+        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+            http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .securityContext(context -> context.requireExplicitSave(false));
+            return http.build();
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private StoreCategoryService storeCategoryService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    private UsernamePasswordAuthenticationToken managerToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        managerToken = authenticationToken(Role.MANAGER);
+
+        doAnswer(invocation -> {
+            jakarta.servlet.FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 등록 성공 시 201 CREATED를 반환한다")
+    void createStoreCategory() throws Exception {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest("한식");
+        StoreCategoryDetailResponse response = storeCategoryResponse("한식");
+        given(storeCategoryService.createStoreCategory(any(StoreCategoryCreateRequest.class), any(UserPrincipal.class)))
+                .willReturn(response);
+
+        mockMvc.perform(post("/api/v1/store-categories")
+                        .with(authentication(managerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.message").value("CREATED"))
+                .andExpect(jsonPath("$.data.name").value("한식"));
+    }
+
+    @Test
+    @DisplayName("가게 카테고리명이 중복되면 400을 반환한다")
+    void createStoreCategoryWithDuplicateName() throws Exception {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest("한식");
+        given(storeCategoryService.createStoreCategory(any(StoreCategoryCreateRequest.class), any(UserPrincipal.class)))
+                .willThrow(new AppException(StoreCategoryErrorCode.DUPLICATE_STORE_CATEGORY_NAME));
+
+        mockMvc.perform(post("/api/v1/store-categories")
+                        .with(authentication(managerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("이미 등록된 가게 카테고리명입니다."));
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 등록 요청값이 유효하지 않으면 400을 반환한다")
+    void createStoreCategoryWithInvalidRequest() throws Exception {
+        StoreCategoryCreateRequest request = new StoreCategoryCreateRequest("");
+
+        mockMvc.perform(post("/api/v1/store-categories")
+                        .with(authentication(managerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("VALIDATION_ERROR"));
+    }
+
+    private StoreCategoryDetailResponse storeCategoryResponse(String name) {
+        return new StoreCategoryDetailResponse(
+                UUID.randomUUID(),
+                name,
+                LocalDateTime.now()
+        );
+    }
+
+    private UsernamePasswordAuthenticationToken authenticationToken(Role role) {
+        UserPrincipal userPrincipal = UserPrincipal.builder()
+                .id(1L)
+                .accountName("manager01")
+                .email("manager01@example.com")
+                .password("password")
+                .nickname("manager")
+                .role(role)
+                .build();
+        return new UsernamePasswordAuthenticationToken(
+                userPrincipal,
+                null,
+                userPrincipal.getAuthorities()
+        );
+    }
+}


### PR DESCRIPTION
Ref #68 

## 작업 내용
- 가게 카테고리 목록 조회 관련 ErrorCode를 추가했습니다.
- 가게 카테고리 목록 응답 DTO와 페이지 응답 DTO를 추가했습니다.
- 삭제되지 않은 가게 카테고리 목록 조회용 Repository 메서드를 추가했습니다.
- 가게 카테고리 목록 조회 서비스 로직을 구현했습니다.
- `GET /api/v1/store-categories` API를 추가했습니다.
- Swagger 명세를 추가했습니다.
- 서비스 테스트와 컨트롤러 테스트를 작성했습니다.

## 주요 변경 사항
- `StoreCategoryErrorCode`
  - 목록 조회 관련 page, size, sort 예외 코드 추가
- `StoreCategoryListResponse`
- `StoreCategoryPageResponse`
- `StoreCategoryRepository`
  - `findAllByDeletedAtIsNull(Pageable pageable)` 추가
- `StoreCategoryService`
  - `getStoreCategories(int page, int size, String sort)` 구현
- `StoreCategoryController`
  - `GET /api/v1/store-categories` 추가

## 처리 내용
- 삭제되지 않은 가게 카테고리만 조회하도록 구현했습니다.
- 페이지 번호, 페이지 크기, 정렬 조건 검증 로직을 추가했습니다.
- 기본 정렬 조건은 `createdAt,DESC`로 적용했습니다.
- 정렬 가능 필드는 `name`, `createdAt`, `updatedAt`으로 제한했습니다.
- 공통 `ApiResponse` 형식으로 `200 OK` 응답을 반환하도록 구현했습니다.

## 테스트
- `.\gradlew.bat test --tests com.sparta.spartadelivery.storecategory.*`

## 체크리스트
- [x] 가게 카테고리 목록 조회 API 구현
- [x] 페이징 처리 적용
- [x] 정렬 조건 적용
- [x] Swagger 명세 추가
- [x] Service Test 작성
- [x] Controller Test 작성
- [x] StoreCategory 테스트 검증 완료