### PR TITLE
Isssue #70 가게 카테고리 상세 조회 API 구현 

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/storecategory/application/service/StoreCategoryService.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/application/service/StoreCategoryService.java
@@ -10,6 +10,7 @@ import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCa
 import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryPageResponse;
 import com.sparta.spartadelivery.user.domain.entity.Role;
 import java.util.Set;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -56,6 +57,12 @@ public class StoreCategoryService {
                 storeCategoryRepository.findAllByDeletedAtIsNull(pageable),
                 normalizedSort
         );
+    }
+
+    public StoreCategoryDetailResponse getStoreCategory(UUID storeCategoryId) {
+        StoreCategory storeCategory = storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)
+                .orElseThrow(() -> new AppException(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND));
+        return StoreCategoryDetailResponse.from(storeCategory);
     }
 
     private void validateCreatePermission(UserPrincipal requester) {

--- a/src/main/java/com/sparta/spartadelivery/storecategory/domain/repository/StoreCategoryRepository.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/domain/repository/StoreCategoryRepository.java
@@ -1,6 +1,7 @@
 package com.sparta.spartadelivery.storecategory.domain.repository;
 
 import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,4 +12,6 @@ public interface StoreCategoryRepository extends JpaRepository<StoreCategory, UU
     boolean existsByNameAndDeletedAtIsNull(String name);
 
     Page<StoreCategory> findAllByDeletedAtIsNull(Pageable pageable);
+
+    Optional<StoreCategory> findByIdAndDeletedAtIsNull(UUID id);
 }

--- a/src/main/java/com/sparta/spartadelivery/storecategory/exception/StoreCategoryErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/exception/StoreCategoryErrorCode.java
@@ -15,7 +15,10 @@ public enum StoreCategoryErrorCode implements BaseErrorCode {
     STORE_CATEGORY_LIST_INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "페이지 크기는 10, 30, 50 중 하나여야 합니다."),
     STORE_CATEGORY_LIST_INVALID_SORT_FORMAT(HttpStatus.BAD_REQUEST, "정렬 조건은 {property},{direction} 형식이어야 합니다."),
     STORE_CATEGORY_LIST_UNSUPPORTED_SORT_PROPERTY(HttpStatus.BAD_REQUEST, "지원하지 않는 정렬 필드입니다."),
-    STORE_CATEGORY_LIST_UNSUPPORTED_SORT_DIRECTION(HttpStatus.BAD_REQUEST, "정렬 방향은 ASC 또는 DESC만 사용할 수 있습니다.");
+    STORE_CATEGORY_LIST_UNSUPPORTED_SORT_DIRECTION(HttpStatus.BAD_REQUEST, "정렬 방향은 ASC 또는 DESC만 사용할 수 있습니다."),
+
+    // 가게 카테고리 상세 조회 API 관련 에러 코드
+    STORE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "가게 카테고리를 찾을 수 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryController.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryController.java
@@ -10,11 +10,13 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -87,6 +89,28 @@ public class StoreCategoryController {
             @RequestParam(required = false) String sort
     ) {
         StoreCategoryPageResponse response = storeCategoryService.getStoreCategories(page, size, sort);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), response));
+    }
+
+    @Operation(
+            summary = "가게 카테고리 상세 조회 API",
+            description = """
+                    가게 카테고리의 상세 정보를 조회합니다.
+
+                    **요청 가능 권한**
+
+                    - ALL
+
+                    **처리 정책**
+
+                    - 삭제되지 않은 가게 카테고리만 조회할 수 있습니다.
+                    """
+    )
+    @GetMapping("/{storeCategoryId}")
+    public ResponseEntity<ApiResponse<StoreCategoryDetailResponse>> getStoreCategory(
+            @PathVariable UUID storeCategoryId
+    ) {
+        StoreCategoryDetailResponse response = storeCategoryService.getStoreCategory(storeCategoryId);
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), response));
     }
 }

--- a/src/test/java/com/sparta/spartadelivery/storecategory/application/StoreCategoryServiceTest.java
+++ b/src/test/java/com/sparta/spartadelivery/storecategory/application/StoreCategoryServiceTest.java
@@ -16,6 +16,7 @@ import com.sparta.spartadelivery.storecategory.exception.StoreCategoryErrorCode;
 import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
 import com.sparta.spartadelivery.user.domain.entity.Role;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -196,6 +197,30 @@ class StoreCategoryServiceTest {
                 .isInstanceOf(AppException.class)
                 .extracting("errorCode")
                 .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_LIST_UNSUPPORTED_SORT_DIRECTION);
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 상세 정보를 조회할 수 있다")
+    void getStoreCategory() {
+        UUID storeCategoryId = UUID.randomUUID();
+        StoreCategory storeCategory = storeCategory("한식");
+        when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)).thenReturn(Optional.of(storeCategory));
+
+        var response = storeCategoryService.getStoreCategory(storeCategoryId);
+
+        assertThat(response.name()).isEqualTo("한식");
+    }
+
+    @Test
+    @DisplayName("상세 조회 대상 가게 카테고리가 없으면 조회할 수 없다")
+    void getStoreCategoryNotFound() {
+        UUID storeCategoryId = UUID.randomUUID();
+        when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> storeCategoryService.getStoreCategory(storeCategoryId))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND);
     }
 
     private StoreCategory storeCategory(String name) {

--- a/src/test/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryControllerTest.java
+++ b/src/test/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryControllerTest.java
@@ -177,6 +177,34 @@ class StoreCategoryControllerTest {
                 .andExpect(jsonPath("$.message").value("페이지 번호는 0 이상이어야 합니다."));
     }
 
+    @Test
+    @DisplayName("가게 카테고리 상세 조회 성공 시 200 OK를 반환한다")
+    void getStoreCategory() throws Exception {
+        UUID storeCategoryId = UUID.randomUUID();
+        StoreCategoryDetailResponse response = storeCategoryResponse("한식");
+        given(storeCategoryService.getStoreCategory(any(UUID.class))).willReturn(response);
+
+        mockMvc.perform(get("/api/v1/store-categories/{storeCategoryId}", storeCategoryId)
+                        .with(authentication(managerToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.name").value("한식"));
+    }
+
+    @Test
+    @DisplayName("상세 조회 대상 가게 카테고리가 없으면 404를 반환한다")
+    void getStoreCategoryNotFound() throws Exception {
+        UUID storeCategoryId = UUID.randomUUID();
+        given(storeCategoryService.getStoreCategory(any(UUID.class)))
+                .willThrow(new AppException(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND));
+
+        mockMvc.perform(get("/api/v1/store-categories/{storeCategoryId}", storeCategoryId)
+                        .with(authentication(managerToken)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("가게 카테고리를 찾을 수 없습니다."));
+    }
+
     private StoreCategoryDetailResponse storeCategoryResponse(String name) {
         return new StoreCategoryDetailResponse(
                 UUID.randomUUID(),


### PR DESCRIPTION
Ref #70

## 작업 내용
- 가게 카테고리 상세 조회 관련 ErrorCode를 추가했습니다.
- 삭제되지 않은 가게 카테고리 단건 조회용 Repository 메서드를 추가했습니다.
- 가게 카테고리 상세 조회 서비스 로직을 구현했습니다.
- `GET /api/v1/store-categories/{storeCategoryId}` API를 추가했습니다.
- Swagger 명세를 추가했습니다.
- 서비스 테스트와 컨트롤러 테스트를 작성했습니다.

## 주요 변경 사항
- `StoreCategoryErrorCode`
  - `STORE_CATEGORY_NOT_FOUND` 추가
- `StoreCategoryRepository`
  - `findByIdAndDeletedAtIsNull(UUID id)` 추가
- `StoreCategoryService`
  - `getStoreCategory(UUID storeCategoryId)` 구현
- `StoreCategoryController`
  - `GET /api/v1/store-categories/{storeCategoryId}` 추가

## 처리 내용
- 삭제되지 않은 가게 카테고리만 상세 조회할 수 있도록 구현했습니다.
- 조회 대상이 없을 경우 `STORE_CATEGORY_NOT_FOUND` 예외를 반환하도록 처리했습니다.
- 공통 `ApiResponse` 형식으로 `200 OK` 응답을 반환하도록 구현했습니다.
- Swagger 명세에 상세 조회 권한과 처리 정책을 반영했습니다.

## 테스트
- `.\gradlew.bat test --tests com.sparta.spartadelivery.storecategory.*`

## 체크리스트
- [x] 가게 카테고리 상세 조회 API 구현
- [x] not found 예외 처리 추가
- [x] Swagger 명세 추가
- [x] Service Test 작성
- [x] Controller Test 작성
- [x] StoreCategory 테스트 검증 완료