### PR TITLE
Issue #72  가게 카테고리 수정 API 구현 

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/storecategory/application/service/StoreCategoryService.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/application/service/StoreCategoryService.java
@@ -6,6 +6,7 @@ import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
 import com.sparta.spartadelivery.storecategory.domain.repository.StoreCategoryRepository;
 import com.sparta.spartadelivery.storecategory.exception.StoreCategoryErrorCode;
 import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
+import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryUpdateRequest;
 import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryDetailResponse;
 import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryPageResponse;
 import com.sparta.spartadelivery.user.domain.entity.Role;
@@ -60,8 +61,26 @@ public class StoreCategoryService {
     }
 
     public StoreCategoryDetailResponse getStoreCategory(UUID storeCategoryId) {
-        StoreCategory storeCategory = storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)
-                .orElseThrow(() -> new AppException(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND));
+        StoreCategory storeCategory = getActiveStoreCategory(storeCategoryId);
+        return StoreCategoryDetailResponse.from(storeCategory);
+    }
+
+    @Transactional
+    public StoreCategoryDetailResponse updateStoreCategory(
+            UUID storeCategoryId,
+            StoreCategoryUpdateRequest request,
+            UserPrincipal requester
+    ) {
+        validateUpdatePermission(requester);
+
+        StoreCategory storeCategory = getActiveStoreCategory(storeCategoryId);
+        String name = request.name().strip();
+
+        if (!storeCategory.getName().equals(name)) {
+            validateDuplicateName(name);
+        }
+
+        storeCategory.update(name);
         return StoreCategoryDetailResponse.from(storeCategory);
     }
 
@@ -76,6 +95,18 @@ public class StoreCategoryService {
         if (storeCategoryRepository.existsByNameAndDeletedAtIsNull(name)) {
             throw new AppException(StoreCategoryErrorCode.DUPLICATE_STORE_CATEGORY_NAME);
         }
+    }
+
+    private void validateUpdatePermission(UserPrincipal requester) {
+        if (requester.getRole() == Role.MANAGER || requester.getRole() == Role.MASTER) {
+            return;
+        }
+        throw new AppException(StoreCategoryErrorCode.STORE_CATEGORY_UPDATE_ACCESS_DENIED);
+    }
+
+    private StoreCategory getActiveStoreCategory(UUID storeCategoryId) {
+        return storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)
+                .orElseThrow(() -> new AppException(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND));
     }
 
     private String normalizeSort(String sort) {

--- a/src/main/java/com/sparta/spartadelivery/storecategory/exception/StoreCategoryErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/exception/StoreCategoryErrorCode.java
@@ -18,7 +18,10 @@ public enum StoreCategoryErrorCode implements BaseErrorCode {
     STORE_CATEGORY_LIST_UNSUPPORTED_SORT_DIRECTION(HttpStatus.BAD_REQUEST, "정렬 방향은 ASC 또는 DESC만 사용할 수 있습니다."),
 
     // 가게 카테고리 상세 조회 API 관련 에러 코드
-    STORE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "가게 카테고리를 찾을 수 없습니다.");
+    STORE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "가게 카테고리를 찾을 수 없습니다."),
+
+    // 가게 카테고리 수정 API 관련 에러 코드
+    STORE_CATEGORY_UPDATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "가게 카테고리를 수정할 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryController.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryController.java
@@ -4,6 +4,7 @@ import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrinc
 import com.sparta.spartadelivery.global.presentation.dto.ApiResponse;
 import com.sparta.spartadelivery.storecategory.application.service.StoreCategoryService;
 import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
+import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryUpdateRequest;
 import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryDetailResponse;
 import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryPageResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -18,6 +19,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
@@ -111,6 +113,32 @@ public class StoreCategoryController {
             @PathVariable UUID storeCategoryId
     ) {
         StoreCategoryDetailResponse response = storeCategoryService.getStoreCategory(storeCategoryId);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), response));
+    }
+
+    @Operation(
+            summary = "가게 카테고리 수정 API",
+            description = """
+                    가게 카테고리 정보를 수정합니다.
+
+                    **요청 가능 권한**
+
+                    - MANAGER
+                    - MASTER
+
+                    **처리 정책**
+
+                    - 삭제되지 않은 가게 카테고리만 수정할 수 있습니다.
+                    - 이름이 변경되는 경우 삭제되지 않은 가게 카테고리 기준으로 중복 검증을 수행합니다.
+                    """
+    )
+    @PutMapping("/{storeCategoryId}")
+    public ResponseEntity<ApiResponse<StoreCategoryDetailResponse>> updateStoreCategory(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID storeCategoryId,
+            @Valid @RequestBody StoreCategoryUpdateRequest request
+    ) {
+        StoreCategoryDetailResponse response = storeCategoryService.updateStoreCategory(storeCategoryId, request, userPrincipal);
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), response));
     }
 }

--- a/src/main/java/com/sparta/spartadelivery/storecategory/presentation/dto/request/StoreCategoryUpdateRequest.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/presentation/dto/request/StoreCategoryUpdateRequest.java
@@ -1,0 +1,13 @@
+package com.sparta.spartadelivery.storecategory.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+
+public record StoreCategoryUpdateRequest(
+        @Schema(description = "가게 카테고리명", example = "중식")
+        @NotBlank(message = "가게 카테고리명은 필수입니다.")
+        @Size(max = 50, message = "가게 카테고리명은 최대 50자까지 입력할 수 있습니다.")
+        String name
+) {
+}

--- a/src/test/java/com/sparta/spartadelivery/storecategory/application/StoreCategoryServiceTest.java
+++ b/src/test/java/com/sparta/spartadelivery/storecategory/application/StoreCategoryServiceTest.java
@@ -14,6 +14,7 @@ import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
 import com.sparta.spartadelivery.storecategory.domain.repository.StoreCategoryRepository;
 import com.sparta.spartadelivery.storecategory.exception.StoreCategoryErrorCode;
 import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
+import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryUpdateRequest;
 import com.sparta.spartadelivery.user.domain.entity.Role;
 import java.util.List;
 import java.util.Optional;
@@ -221,6 +222,111 @@ class StoreCategoryServiceTest {
                 .isInstanceOf(AppException.class)
                 .extracting("errorCode")
                 .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("MANAGER 권한 사용자는 가게 카테고리를 수정할 수 있다")
+    void updateStoreCategoryByManager() {
+        UUID storeCategoryId = UUID.randomUUID();
+        StoreCategory storeCategory = storeCategory("한식");
+        StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest("중식");
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)).thenReturn(Optional.of(storeCategory));
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("중식")).thenReturn(false);
+
+        var response = storeCategoryService.updateStoreCategory(storeCategoryId, request, requester);
+
+        assertThat(storeCategory.getName()).isEqualTo("중식");
+        assertThat(response.name()).isEqualTo("중식");
+    }
+
+    @Test
+    @DisplayName("MASTER 권한 사용자는 가게 카테고리를 수정할 수 있다")
+    void updateStoreCategoryByMaster() {
+        UUID storeCategoryId = UUID.randomUUID();
+        StoreCategory storeCategory = storeCategory("한식");
+        StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest("중식");
+        UserPrincipal requester = principal(Role.MASTER);
+        when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)).thenReturn(Optional.of(storeCategory));
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("중식")).thenReturn(false);
+
+        var response = storeCategoryService.updateStoreCategory(storeCategoryId, request, requester);
+
+        assertThat(response.name()).isEqualTo("중식");
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 수정 요청값은 저장 전에 앞뒤 공백을 제거한다")
+    void updateStoreCategoryWithTrimmedName() {
+        UUID storeCategoryId = UUID.randomUUID();
+        StoreCategory storeCategory = storeCategory("한식");
+        StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest(" 중식 ");
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)).thenReturn(Optional.of(storeCategory));
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("중식")).thenReturn(false);
+
+        storeCategoryService.updateStoreCategory(storeCategoryId, request, requester);
+
+        assertThat(storeCategory.getName()).isEqualTo("중식");
+    }
+
+    @Test
+    @DisplayName("가게 카테고리명이 변경되지 않으면 중복 검증 없이 수정할 수 있다")
+    void updateStoreCategoryWithSameNameSkipsDuplicateCheck() {
+        UUID storeCategoryId = UUID.randomUUID();
+        StoreCategory storeCategory = storeCategory("한식");
+        StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest("한식");
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)).thenReturn(Optional.of(storeCategory));
+
+        storeCategoryService.updateStoreCategory(storeCategoryId, request, requester);
+
+        verify(storeCategoryRepository, never()).existsByNameAndDeletedAtIsNull(any());
+    }
+
+    @Test
+    @DisplayName("CUSTOMER 권한 사용자는 가게 카테고리를 수정할 수 없다")
+    void updateStoreCategoryByCustomerDenied() {
+        UUID storeCategoryId = UUID.randomUUID();
+        StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest("중식");
+        UserPrincipal requester = principal(Role.CUSTOMER);
+
+        assertThatThrownBy(() -> storeCategoryService.updateStoreCategory(storeCategoryId, request, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_UPDATE_ACCESS_DENIED);
+
+        verify(storeCategoryRepository, never()).findByIdAndDeletedAtIsNull(any());
+    }
+
+    @Test
+    @DisplayName("수정할 가게 카테고리가 없으면 수정할 수 없다")
+    void updateStoreCategoryNotFound() {
+        UUID storeCategoryId = UUID.randomUUID();
+        StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest("중식");
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> storeCategoryService.updateStoreCategory(storeCategoryId, request, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("변경하려는 가게 카테고리명이 중복되면 수정할 수 없다")
+    void updateStoreCategoryWithDuplicateName() {
+        UUID storeCategoryId = UUID.randomUUID();
+        StoreCategory storeCategory = storeCategory("한식");
+        StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest("중식");
+        UserPrincipal requester = principal(Role.MANAGER);
+        when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)).thenReturn(Optional.of(storeCategory));
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("중식")).thenReturn(true);
+
+        assertThatThrownBy(() -> storeCategoryService.updateStoreCategory(storeCategoryId, request, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.DUPLICATE_STORE_CATEGORY_NAME);
     }
 
     private StoreCategory storeCategory(String name) {

--- a/src/test/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryControllerTest.java
+++ b/src/test/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryControllerTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.doAnswer;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -17,6 +18,7 @@ import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrinc
 import com.sparta.spartadelivery.storecategory.application.service.StoreCategoryService;
 import com.sparta.spartadelivery.storecategory.exception.StoreCategoryErrorCode;
 import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryCreateRequest;
+import com.sparta.spartadelivery.storecategory.presentation.dto.request.StoreCategoryUpdateRequest;
 import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryDetailResponse;
 import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryListResponse;
 import com.sparta.spartadelivery.storecategory.presentation.dto.response.StoreCategoryPageResponse;
@@ -201,6 +203,71 @@ class StoreCategoryControllerTest {
 
         mockMvc.perform(get("/api/v1/store-categories/{storeCategoryId}", storeCategoryId)
                         .with(authentication(managerToken)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("가게 카테고리를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 수정 성공 시 200 OK를 반환한다")
+    void updateStoreCategory() throws Exception {
+        UUID storeCategoryId = UUID.randomUUID();
+        StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest("중식");
+        StoreCategoryDetailResponse response = storeCategoryResponse("중식");
+        given(storeCategoryService.updateStoreCategory(any(UUID.class), any(StoreCategoryUpdateRequest.class), any(UserPrincipal.class)))
+                .willReturn(response);
+
+        mockMvc.perform(put("/api/v1/store-categories/{storeCategoryId}", storeCategoryId)
+                        .with(authentication(managerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("SUCCESS"))
+                .andExpect(jsonPath("$.data.name").value("중식"));
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 수정 요청값이 유효하지 않으면 400을 반환한다")
+    void updateStoreCategoryWithInvalidRequest() throws Exception {
+        UUID storeCategoryId = UUID.randomUUID();
+        StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest("");
+
+        mockMvc.perform(put("/api/v1/store-categories/{storeCategoryId}", storeCategoryId)
+                        .with(authentication(managerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 수정 권한이 없으면 403을 반환한다")
+    void updateStoreCategoryAccessDenied() throws Exception {
+        UUID storeCategoryId = UUID.randomUUID();
+        StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest("중식");
+        given(storeCategoryService.updateStoreCategory(any(UUID.class), any(StoreCategoryUpdateRequest.class), any(UserPrincipal.class)))
+                .willThrow(new AppException(StoreCategoryErrorCode.STORE_CATEGORY_UPDATE_ACCESS_DENIED));
+
+        mockMvc.perform(put("/api/v1/store-categories/{storeCategoryId}", storeCategoryId)
+                        .with(authentication(managerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("가게 카테고리를 수정할 권한이 없습니다."));
+    }
+
+    @Test
+    @DisplayName("수정할 가게 카테고리가 없으면 404를 반환한다")
+    void updateStoreCategoryNotFound() throws Exception {
+        UUID storeCategoryId = UUID.randomUUID();
+        StoreCategoryUpdateRequest request = new StoreCategoryUpdateRequest("중식");
+        given(storeCategoryService.updateStoreCategory(any(UUID.class), any(StoreCategoryUpdateRequest.class), any(UserPrincipal.class)))
+                .willThrow(new AppException(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND));
+
+        mockMvc.perform(put("/api/v1/store-categories/{storeCategoryId}", storeCategoryId)
+                        .with(authentication(managerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.message").value("가게 카테고리를 찾을 수 없습니다."));
     }


### PR DESCRIPTION
Ref #72

## 작업 내용
- 가게 카테고리 수정 관련 ErrorCode를 추가했습니다.
- 가게 카테고리 수정 요청 DTO를 추가했습니다.
- 가게 카테고리 수정 서비스 로직을 구현했습니다.
- `PUT /api/v1/store-categories/{storeCategoryId}` API를 추가했습니다.
- Swagger 명세를 추가했습니다.
- 서비스 테스트와 컨트롤러 테스트를 작성했습니다.

## 주요 변경 사항
- `StoreCategoryErrorCode`
  - `STORE_CATEGORY_UPDATE_ACCESS_DENIED` 추가
- `StoreCategoryUpdateRequest`
- `StoreCategoryService`
  - `updateStoreCategory(UUID storeCategoryId, StoreCategoryUpdateRequest request, UserPrincipal requester)` 구현
- `StoreCategoryController`
  - `PUT /api/v1/store-categories/{storeCategoryId}` 추가

## 처리 내용
- MANAGER, MASTER 권한만 수정 가능하도록 검증했습니다.
- 삭제되지 않은 가게 카테고리만 수정할 수 있도록 처리했습니다.
- 이름이 변경되는 경우에만 삭제되지 않은 가게 카테고리 기준으로 중복 검증을 수행하도록 구현했습니다.
- 이름이 동일한 경우에는 중복 검증을 생략하도록 처리했습니다.
- 공통 `ApiResponse` 형식으로 `200 OK` 응답을 반환하도록 구현했습니다.

## 테스트
- `.\gradlew.bat test --tests com.sparta.spartadelivery.storecategory.*`

## 체크리스트
- [x] 가게 카테고리 수정 API 구현
- [x] 수정 권한 검증 추가
- [x] 이름 중복 검증 로직 추가
- [x] Swagger 명세 추가
- [x] Service Test 작성
- [x] Controller Test 작성
- [x] StoreCategory 테스트 검증 완료