### PR TITLE
Issue #74 가게 카테고리 삭제 API 구현

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/storecategory/application/service/StoreCategoryService.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/application/service/StoreCategoryService.java
@@ -60,9 +60,16 @@ public class StoreCategoryService {
     }
 
     public StoreCategoryDetailResponse getStoreCategory(UUID storeCategoryId) {
-        StoreCategory storeCategory = storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)
-                .orElseThrow(() -> new AppException(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND));
+        StoreCategory storeCategory = getActiveStoreCategory(storeCategoryId);
         return StoreCategoryDetailResponse.from(storeCategory);
+    }
+
+    @Transactional
+    public void deleteStoreCategory(UUID storeCategoryId, UserPrincipal requester) {
+        validateDeletePermission(requester);
+
+        StoreCategory storeCategory = getActiveStoreCategory(storeCategoryId);
+        storeCategory.markDeleted(requester.getAccountName());
     }
 
     private void validateCreatePermission(UserPrincipal requester) {
@@ -76,6 +83,18 @@ public class StoreCategoryService {
         if (storeCategoryRepository.existsByNameAndDeletedAtIsNull(name)) {
             throw new AppException(StoreCategoryErrorCode.DUPLICATE_STORE_CATEGORY_NAME);
         }
+    }
+
+    private void validateDeletePermission(UserPrincipal requester) {
+        if (requester.getRole() == Role.MASTER) {
+            return;
+        }
+        throw new AppException(StoreCategoryErrorCode.STORE_CATEGORY_DELETE_ACCESS_DENIED);
+    }
+
+    private StoreCategory getActiveStoreCategory(UUID storeCategoryId) {
+        return storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)
+                .orElseThrow(() -> new AppException(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND));
     }
 
     private String normalizeSort(String sort) {

--- a/src/main/java/com/sparta/spartadelivery/storecategory/exception/StoreCategoryErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/exception/StoreCategoryErrorCode.java
@@ -18,7 +18,10 @@ public enum StoreCategoryErrorCode implements BaseErrorCode {
     STORE_CATEGORY_LIST_UNSUPPORTED_SORT_DIRECTION(HttpStatus.BAD_REQUEST, "정렬 방향은 ASC 또는 DESC만 사용할 수 있습니다."),
 
     // 가게 카테고리 상세 조회 API 관련 에러 코드
-    STORE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "가게 카테고리를 찾을 수 없습니다.");
+    STORE_CATEGORY_NOT_FOUND(HttpStatus.NOT_FOUND, "가게 카테고리를 찾을 수 없습니다."),
+
+    // 가게 카테고리 삭제 API 관련 에러 코드
+    STORE_CATEGORY_DELETE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "가게 카테고리를 삭제할 권한이 없습니다.");
 
     private final HttpStatus status;
     private final String message;

--- a/src/main/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryController.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryController.java
@@ -15,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -112,5 +113,29 @@ public class StoreCategoryController {
     ) {
         StoreCategoryDetailResponse response = storeCategoryService.getStoreCategory(storeCategoryId);
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), response));
+    }
+
+    @Operation(
+            summary = "가게 카테고리 삭제 API",
+            description = """
+                    가게 카테고리를 soft delete 방식으로 삭제 처리합니다.
+
+                    **요청 가능 권한**
+
+                    - MASTER
+
+                    **처리 정책**
+
+                    - 실제 데이터를 삭제하지 않고 deletedAt, deletedBy를 기록합니다.
+                    - 이미 삭제된 가게 카테고리는 삭제 대상으로 조회되지 않습니다.
+                    """
+    )
+    @DeleteMapping("/{storeCategoryId}")
+    public ResponseEntity<ApiResponse<Void>> deleteStoreCategory(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @PathVariable UUID storeCategoryId
+    ) {
+        storeCategoryService.deleteStoreCategory(storeCategoryId, userPrincipal);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), null));
     }
 }

--- a/src/test/java/com/sparta/spartadelivery/storecategory/application/StoreCategoryServiceTest.java
+++ b/src/test/java/com/sparta/spartadelivery/storecategory/application/StoreCategoryServiceTest.java
@@ -223,6 +223,47 @@ class StoreCategoryServiceTest {
                 .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND);
     }
 
+    @Test
+    @DisplayName("MASTER 권한 사용자는 가게 카테고리를 삭제할 수 있다")
+    void deleteStoreCategoryByMaster() {
+        UUID storeCategoryId = UUID.randomUUID();
+        StoreCategory storeCategory = storeCategory("한식");
+        UserPrincipal requester = principal(Role.MASTER);
+        when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)).thenReturn(Optional.of(storeCategory));
+
+        storeCategoryService.deleteStoreCategory(storeCategoryId, requester);
+
+        assertThat(storeCategory.isDeleted()).isTrue();
+        assertThat(storeCategory.getDeletedBy()).isEqualTo("manager01");
+    }
+
+    @Test
+    @DisplayName("MANAGER 권한 사용자는 가게 카테고리를 삭제할 수 없다")
+    void deleteStoreCategoryByManagerDenied() {
+        UUID storeCategoryId = UUID.randomUUID();
+        UserPrincipal requester = principal(Role.MANAGER);
+
+        assertThatThrownBy(() -> storeCategoryService.deleteStoreCategory(storeCategoryId, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_DELETE_ACCESS_DENIED);
+
+        verify(storeCategoryRepository, never()).findByIdAndDeletedAtIsNull(any());
+    }
+
+    @Test
+    @DisplayName("삭제할 가게 카테고리가 없으면 삭제할 수 없다")
+    void deleteStoreCategoryNotFound() {
+        UUID storeCategoryId = UUID.randomUUID();
+        UserPrincipal requester = principal(Role.MASTER);
+        when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> storeCategoryService.deleteStoreCategory(storeCategoryId, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND);
+    }
+
     private StoreCategory storeCategory(String name) {
         return StoreCategory.builder()
                 .name(name)

--- a/src/test/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryControllerTest.java
+++ b/src/test/java/com/sparta/spartadelivery/storecategory/presentation/controller/StoreCategoryControllerTest.java
@@ -3,6 +3,8 @@ package com.sparta.spartadelivery.storecategory.presentation.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -76,10 +78,12 @@ class StoreCategoryControllerTest {
     private JwtAuthenticationFilter jwtAuthenticationFilter;
 
     private UsernamePasswordAuthenticationToken managerToken;
+    private UsernamePasswordAuthenticationToken masterToken;
 
     @BeforeEach
     void setUp() throws Exception {
         managerToken = authenticationToken(Role.MANAGER);
+        masterToken = authenticationToken(Role.MASTER);
 
         doAnswer(invocation -> {
             jakarta.servlet.FilterChain chain = invocation.getArgument(2);
@@ -201,6 +205,44 @@ class StoreCategoryControllerTest {
 
         mockMvc.perform(get("/api/v1/store-categories/{storeCategoryId}", storeCategoryId)
                         .with(authentication(managerToken)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("가게 카테고리를 찾을 수 없습니다."));
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 삭제 성공 시 200 OK를 반환한다")
+    void deleteStoreCategory() throws Exception {
+        UUID storeCategoryId = UUID.randomUUID();
+
+        mockMvc.perform(delete("/api/v1/store-categories/{storeCategoryId}", storeCategoryId)
+                        .with(authentication(masterToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("SUCCESS"));
+    }
+
+    @Test
+    @DisplayName("가게 카테고리 삭제 권한이 없으면 403을 반환한다")
+    void deleteStoreCategoryAccessDenied() throws Exception {
+        UUID storeCategoryId = UUID.randomUUID();
+        doThrow(new AppException(StoreCategoryErrorCode.STORE_CATEGORY_DELETE_ACCESS_DENIED))
+                .when(storeCategoryService).deleteStoreCategory(any(UUID.class), any(UserPrincipal.class));
+
+        mockMvc.perform(delete("/api/v1/store-categories/{storeCategoryId}", storeCategoryId)
+                        .with(authentication(managerToken)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("가게 카테고리를 삭제할 권한이 없습니다."));
+    }
+
+    @Test
+    @DisplayName("삭제할 가게 카테고리가 없으면 404를 반환한다")
+    void deleteStoreCategoryNotFound() throws Exception {
+        UUID storeCategoryId = UUID.randomUUID();
+        doThrow(new AppException(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND))
+                .when(storeCategoryService).deleteStoreCategory(any(UUID.class), any(UserPrincipal.class));
+
+        mockMvc.perform(delete("/api/v1/store-categories/{storeCategoryId}", storeCategoryId)
+                        .with(authentication(masterToken)))
                 .andExpect(status().isNotFound())
                 .andExpect(jsonPath("$.message").value("가게 카테고리를 찾을 수 없습니다."));
     }


### PR DESCRIPTION
## 작업 내용
- 가게 카테고리 삭제 관련 ErrorCode를 추가했습니다.
- 가게 카테고리 삭제 서비스 로직을 구현했습니다.
- `DELETE /api/v1/store-categories/{storeCategoryId}` API를 추가했습니다.
- Swagger 명세를 추가했습니다.
- 서비스 테스트와 컨트롤러 테스트를 작성했습니다.

## 주요 변경 사항
- `StoreCategoryErrorCode`
  - `STORE_CATEGORY_DELETE_ACCESS_DENIED` 추가
- `StoreCategoryService`
  - `deleteStoreCategory(UUID storeCategoryId, UserPrincipal requester)` 구현
- `StoreCategoryController`
  - `DELETE /api/v1/store-categories/{storeCategoryId}` 추가

## 처리 내용
- MASTER 권한만 삭제 가능하도록 검증했습니다.
- 삭제되지 않은 가게 카테고리만 삭제 대상으로 조회하도록 처리했습니다.
- `markDeleted`를 사용해 soft delete 방식으로 삭제 시각과 삭제자를 기록하도록 구현했습니다.
- 공통 `ApiResponse` 형식으로 `200 OK` 응답을 반환하도록 구현했습니다.
- Swagger 명세에 삭제 권한과 soft delete 정책을 반영했습니다.

## 테스트
- `.\gradlew.bat test --tests com.sparta.spartadelivery.storecategory.*`

## 체크리스트
- [x] 가게 카테고리 삭제 API 구현
- [x] 삭제 권한 검증 추가
- [x] soft delete 처리 구현
- [x] Swagger 명세 추가
- [x] Service Test 작성
- [x] Controller Test 작성
- [x] StoreCategory 테스트 검증 완료