### PR TITLE
Issue #80 StoreCategory 기본 카테고리 시드 데이터 추가

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/storecategory/application/bootstrap/StoreCategorySeeder.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/application/bootstrap/StoreCategorySeeder.java
@@ -1,0 +1,43 @@
+package com.sparta.spartadelivery.storecategory.application.bootstrap;
+
+import com.sparta.spartadelivery.storecategory.application.config.StoreCategorySeedProperties;
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import com.sparta.spartadelivery.storecategory.domain.repository.StoreCategoryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class StoreCategorySeeder implements ApplicationRunner {
+
+    private final StoreCategoryRepository storeCategoryRepository;
+    private final StoreCategorySeedProperties seedProperties;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        if (!seedProperties.enabled()) {
+            return;
+        }
+
+        List<StoreCategory> categoriesToSave = seedProperties.values().stream()
+                .map(String::strip)
+                .filter(name -> !name.isBlank())
+                .distinct()
+                .filter(name -> !storeCategoryRepository.existsByNameAndDeletedAtIsNull(name))
+                .map(name -> StoreCategory.builder()
+                        .name(name)
+                        .build())
+                .toList();
+
+        if (categoriesToSave.isEmpty()) {
+            return;
+        }
+
+        storeCategoryRepository.saveAll(categoriesToSave);
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/storecategory/application/config/StoreCategorySeedProperties.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/application/config/StoreCategorySeedProperties.java
@@ -1,0 +1,15 @@
+package com.sparta.spartadelivery.storecategory.application.config;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.seed.store-categories")
+public record StoreCategorySeedProperties(
+        boolean enabled,
+        List<String> values
+) {
+
+    public StoreCategorySeedProperties {
+        values = values == null ? List.of() : List.copyOf(values);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,3 +25,13 @@ logging:
 jwt:
   secret: ${JWT_SECRET:please-change-this-secret-key-for-local-dev-at-least-32bytes}
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:3600000}
+
+app:
+  seed:
+    store-categories:
+      enabled: true
+      values:
+        - 한식
+        - 중식
+        - 일식
+        - 양식

--- a/src/test/java/com/sparta/spartadelivery/storecategory/application/bootstrap/StoreCategorySeederTest.java
+++ b/src/test/java/com/sparta/spartadelivery/storecategory/application/bootstrap/StoreCategorySeederTest.java
@@ -1,0 +1,77 @@
+package com.sparta.spartadelivery.storecategory.application.bootstrap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sparta.spartadelivery.storecategory.application.config.StoreCategorySeedProperties;
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import com.sparta.spartadelivery.storecategory.domain.repository.StoreCategoryRepository;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.DefaultApplicationArguments;
+
+@ExtendWith(MockitoExtension.class)
+class StoreCategorySeederTest {
+
+    @Mock
+    private StoreCategoryRepository storeCategoryRepository;
+
+    private ArgumentCaptor<Iterable<StoreCategory>> categoriesCaptor;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        categoriesCaptor = ArgumentCaptor.forClass(Iterable.class);
+    }
+
+    @Test
+    @DisplayName("시드 데이터가 활성화되어 있으면 없는 카테고리만 저장한다")
+    void seedStoreCategories() throws Exception {
+        StoreCategorySeedProperties seedProperties = new StoreCategorySeedProperties(
+                true,
+                List.of("한식", " 중식 ", "한식", "", "일식")
+        );
+        StoreCategorySeeder seeder = new StoreCategorySeeder(storeCategoryRepository, seedProperties);
+
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("한식")).thenReturn(true);
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("중식")).thenReturn(false);
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("일식")).thenReturn(false);
+
+        seeder.run(new DefaultApplicationArguments(new String[0]));
+
+        verify(storeCategoryRepository).saveAll(categoriesCaptor.capture());
+        List<String> savedNames = toNames(categoriesCaptor.getValue());
+        assertThat(savedNames).containsExactly("중식", "일식");
+    }
+
+    @Test
+    @DisplayName("시드 데이터가 비활성화되어 있으면 저장하지 않는다")
+    void skipWhenSeedDisabled() throws Exception {
+        StoreCategorySeedProperties seedProperties = new StoreCategorySeedProperties(
+                false,
+                List.of("한식", "중식")
+        );
+        StoreCategorySeeder seeder = new StoreCategorySeeder(storeCategoryRepository, seedProperties);
+
+        seeder.run(new DefaultApplicationArguments(new String[0]));
+
+        verify(storeCategoryRepository, never()).existsByNameAndDeletedAtIsNull(any());
+        verify(storeCategoryRepository, never()).saveAll(any());
+    }
+
+    private List<String> toNames(Iterable<StoreCategory> categories) {
+        return StreamSupport.stream(categories.spliterator(), false)
+                .map(StoreCategory::getName)
+                .toList();
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -16,3 +16,8 @@ spring:
 jwt:
   secret: test-secret-key-for-jwt-token-provider-at-least-32bytes
   access-token-expiration: 3600000
+
+app:
+  seed:
+    store-categories:
+      enabled: false


### PR DESCRIPTION
Ref #80 

## 작업 내용
- `StoreCategory` 기본 시드 데이터 설정 추가
- 앱 시작 시 기본 카테고리를 자동으로 적재하는 `StoreCategorySeeder` 추가
- 이미 존재하는 카테고리는 다시 저장하지 않도록 멱등 처리 적용
- 테스트 프로필에서는 자동 시드가 실행되지 않도록 설정 분리
- `StoreCategorySeeder` 테스트 추가

## 기본 시드 데이터
- 한식
- 중식
- 일식
- 양식

## 작업 이유
`StoreCategory`의 대표 카테고리는 사용자가 매번 직접 생성하는 데이터라기보다 서비스가 기본 제공해야 하는 기준 데이터에 가깝다고 판단했습니다.  
앱 시작 시 자동으로 적재되도록 해서 로컬/개발 환경에서 초기 데이터 세팅 부담을 줄이고, 환경별 데이터 편차도 줄이도록 했습니다.

또한 현재 프로젝트는 JPA 엔티티와 Auditing 중심 구조이기 때문에 `data.sql`보다는 애플리케이션 레벨 시더 방식이 더 일관된다고 봤습니다.

## 검증 내용
- `.\gradlew.bat test --tests com.sparta.spartadelivery.storecategory.*`

## 참고 사항
- 시드 데이터는 `app.seed.store-categories` 설정으로 관리합니다.
- 테스트 환경에서는 `app.seed.store-categories.enabled=false`로 비활성화했습니다.

<img width="2003" height="509" alt="image" src="https://github.com/user-attachments/assets/c4675782-b47a-470a-8410-07539f876488" />

