### PR TITLE
Issue #82 가게 등록 API 구현

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/store/application/service/StoreService.java
+++ b/src/main/java/com/sparta/spartadelivery/store/application/service/StoreService.java
@@ -1,0 +1,77 @@
+package com.sparta.spartadelivery.store.application.service;
+
+import com.sparta.spartadelivery.area.domain.entity.Area;
+import com.sparta.spartadelivery.area.domain.repository.AreaRepository;
+import com.sparta.spartadelivery.area.exception.AreaErrorCode;
+import com.sparta.spartadelivery.auth.exception.AuthErrorCode;
+import com.sparta.spartadelivery.global.exception.AppException;
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.store.domain.entity.Store;
+import com.sparta.spartadelivery.store.domain.repository.StoreRepository;
+import com.sparta.spartadelivery.store.exception.StoreErrorCode;
+import com.sparta.spartadelivery.store.presentation.dto.request.StoreCreateRequest;
+import com.sparta.spartadelivery.store.presentation.dto.response.StoreDetailResponse;
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import com.sparta.spartadelivery.storecategory.domain.repository.StoreCategoryRepository;
+import com.sparta.spartadelivery.storecategory.exception.StoreCategoryErrorCode;
+import com.sparta.spartadelivery.user.domain.entity.Role;
+import com.sparta.spartadelivery.user.domain.entity.UserEntity;
+import com.sparta.spartadelivery.user.domain.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class StoreService {
+
+    private final StoreRepository storeRepository;
+    private final UserRepository userRepository;
+    private final StoreCategoryRepository storeCategoryRepository;
+    private final AreaRepository areaRepository;
+
+    @Transactional
+    public StoreDetailResponse createStore(StoreCreateRequest request, UserPrincipal requester) {
+        validateCreatePermission(requester);
+
+        UserEntity owner = userRepository.findByIdAndDeletedAtIsNull(requester.getId())
+                .orElseThrow(() -> new AppException(AuthErrorCode.USER_NOT_FOUND));
+        StoreCategory storeCategory = storeCategoryRepository.findByIdAndDeletedAtIsNull(request.storeCategoryId())
+                .orElseThrow(() -> new AppException(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND));
+        Area area = areaRepository.findByIdAndDeletedAtIsNull(request.areaId())
+                .orElseThrow(() -> new AppException(AreaErrorCode.AREA_NOT_FOUND));
+
+        Store store = Store.builder()
+                .owner(owner)
+                .storeCategory(storeCategory)
+                .area(area)
+                .name(request.name().strip())
+                .address(request.address().strip())
+                .phone(normalizePhone(request.phone()))
+                .build();
+
+        return StoreDetailResponse.from(storeRepository.save(store));
+    }
+
+    private void validateCreatePermission(UserPrincipal requester) {
+        if (requester.getRole() == Role.OWNER) {
+            return;
+        }
+        if (requester.getRole() == Role.CUSTOMER
+                || requester.getRole() == Role.MANAGER
+                || requester.getRole() == Role.MASTER) {
+            throw new AppException(StoreErrorCode.STORE_CREATE_OWNER_ROLE_REQUIRED);
+        }
+        throw new AppException(StoreErrorCode.STORE_CREATE_ACCESS_DENIED);
+    }
+
+    private String normalizePhone(String phone) {
+        if (phone == null) {
+            return null;
+        }
+
+        String normalizedPhone = phone.strip();
+        return normalizedPhone.isEmpty() ? null : normalizedPhone;
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/store/exception/StoreErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/store/exception/StoreErrorCode.java
@@ -1,0 +1,19 @@
+package com.sparta.spartadelivery.store.exception;
+
+import com.sparta.spartadelivery.global.exception.BaseErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum StoreErrorCode implements BaseErrorCode {
+    STORE_CREATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "가게를 등록할 권한이 없습니다."),
+    STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "가게를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    StoreErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/store/exception/StoreErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/store/exception/StoreErrorCode.java
@@ -7,6 +7,7 @@ import org.springframework.http.HttpStatus;
 @Getter
 public enum StoreErrorCode implements BaseErrorCode {
     STORE_CREATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "가게를 등록할 권한이 없습니다."),
+    STORE_CREATE_OWNER_ROLE_REQUIRED(HttpStatus.FORBIDDEN, "가게는 OWNER 권한 사용자만 등록할 수 있습니다."),
     STORE_NOT_FOUND(HttpStatus.NOT_FOUND, "가게를 찾을 수 없습니다.");
 
     private final HttpStatus status;

--- a/src/main/java/com/sparta/spartadelivery/store/presentation/controller/StoreController.java
+++ b/src/main/java/com/sparta/spartadelivery/store/presentation/controller/StoreController.java
@@ -1,0 +1,52 @@
+package com.sparta.spartadelivery.store.presentation.controller;
+
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.global.presentation.dto.ApiResponse;
+import com.sparta.spartadelivery.store.application.service.StoreService;
+import com.sparta.spartadelivery.store.presentation.dto.request.StoreCreateRequest;
+import com.sparta.spartadelivery.store.presentation.dto.response.StoreDetailResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/stores")
+@RequiredArgsConstructor
+@Tag(name = "Store", description = "가게 관리 API")
+public class StoreController {
+
+    private final StoreService storeService;
+
+    @Operation(
+            summary = "가게 등록 API",
+            description = """
+                    새로운 가게를 등록합니다.
+
+                    **요청 가능 권한**
+
+                    - OWNER
+
+                    **처리 정책**
+
+                    - 로그인한 OWNER 사용자를 가게 소유자로 저장합니다.
+                    - 삭제되지 않은 가게 카테고리와 지역만 참조할 수 있습니다.
+                    """
+    )
+    @PostMapping
+    public ResponseEntity<ApiResponse<StoreDetailResponse>> createStore(
+            @AuthenticationPrincipal UserPrincipal userPrincipal,
+            @Valid @RequestBody StoreCreateRequest request
+    ) {
+        StoreDetailResponse response = storeService.createStore(request, userPrincipal);
+        return ResponseEntity.status(HttpStatus.CREATED)
+                .body(ApiResponse.success(HttpStatus.CREATED.value(), "CREATED", response));
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/store/presentation/dto/request/StoreCreateRequest.java
+++ b/src/main/java/com/sparta/spartadelivery/store/presentation/dto/request/StoreCreateRequest.java
@@ -1,0 +1,32 @@
+package com.sparta.spartadelivery.store.presentation.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import java.util.UUID;
+
+public record StoreCreateRequest(
+        @Schema(description = "가게 카테고리 ID", example = "550e8400-e29b-41d4-a716-446655440010")
+        @NotNull(message = "가게 카테고리 ID는 필수입니다.")
+        UUID storeCategoryId,
+
+        @Schema(description = "지역 ID", example = "550e8400-e29b-41d4-a716-446655440011")
+        @NotNull(message = "지역 ID는 필수입니다.")
+        UUID areaId,
+
+        @Schema(description = "가게명", example = "스파르타 분식")
+        @NotBlank(message = "가게명은 필수입니다.")
+        @Size(max = 100, message = "가게명은 최대 100자까지 입력할 수 있습니다.")
+        String name,
+
+        @Schema(description = "가게 주소", example = "서울특별시 강남구 테헤란로 123")
+        @NotBlank(message = "가게 주소는 필수입니다.")
+        @Size(max = 255, message = "가게 주소는 최대 255자까지 입력할 수 있습니다.")
+        String address,
+
+        @Schema(description = "가게 연락처", example = "02-1234-5678")
+        @Size(max = 20, message = "가게 연락처는 최대 20자까지 입력할 수 있습니다.")
+        String phone
+) {
+}

--- a/src/main/java/com/sparta/spartadelivery/store/presentation/dto/response/StoreDetailResponse.java
+++ b/src/main/java/com/sparta/spartadelivery/store/presentation/dto/response/StoreDetailResponse.java
@@ -1,0 +1,55 @@
+package com.sparta.spartadelivery.store.presentation.dto.response;
+
+import com.sparta.spartadelivery.store.domain.entity.Store;
+import io.swagger.v3.oas.annotations.media.Schema;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+public record StoreDetailResponse(
+        @Schema(description = "가게 ID", example = "550e8400-e29b-41d4-a716-446655440012")
+        UUID id,
+
+        @Schema(description = "가게 소유자 ID", example = "1")
+        Long ownerId,
+
+        @Schema(description = "가게 카테고리 ID", example = "550e8400-e29b-41d4-a716-446655440010")
+        UUID storeCategoryId,
+
+        @Schema(description = "지역 ID", example = "550e8400-e29b-41d4-a716-446655440011")
+        UUID areaId,
+
+        @Schema(description = "가게명", example = "스파르타 분식")
+        String name,
+
+        @Schema(description = "가게 주소", example = "서울특별시 강남구 테헤란로 123")
+        String address,
+
+        @Schema(description = "가게 연락처", example = "02-1234-5678")
+        String phone,
+
+        @Schema(description = "평균 평점", example = "0.0")
+        BigDecimal averageRating,
+
+        @Schema(description = "숨김 여부", example = "false")
+        boolean hidden,
+
+        @Schema(description = "가게 생성 일시", example = "2026-04-24T12:00:00")
+        LocalDateTime createdAt
+) {
+
+    public static StoreDetailResponse from(Store store) {
+        return new StoreDetailResponse(
+                store.getId(),
+                store.getOwner().getId(),
+                store.getStoreCategory().getId(),
+                store.getArea().getId(),
+                store.getName(),
+                store.getAddress(),
+                store.getPhone(),
+                store.getAverageRating(),
+                store.isHidden(),
+                store.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/storecategory/application/bootstrap/StoreCategorySeeder.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/application/bootstrap/StoreCategorySeeder.java
@@ -1,0 +1,43 @@
+package com.sparta.spartadelivery.storecategory.application.bootstrap;
+
+import com.sparta.spartadelivery.storecategory.application.config.StoreCategorySeedProperties;
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import com.sparta.spartadelivery.storecategory.domain.repository.StoreCategoryRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+@Component
+@RequiredArgsConstructor
+public class StoreCategorySeeder implements ApplicationRunner {
+
+    private final StoreCategoryRepository storeCategoryRepository;
+    private final StoreCategorySeedProperties seedProperties;
+
+    @Override
+    @Transactional
+    public void run(ApplicationArguments args) {
+        if (!seedProperties.enabled()) {
+            return;
+        }
+
+        List<StoreCategory> categoriesToSave = seedProperties.values().stream()
+                .map(String::strip)
+                .filter(name -> !name.isBlank())
+                .distinct()
+                .filter(name -> !storeCategoryRepository.existsByNameAndDeletedAtIsNull(name))
+                .map(name -> StoreCategory.builder()
+                        .name(name)
+                        .build())
+                .toList();
+
+        if (categoriesToSave.isEmpty()) {
+            return;
+        }
+
+        storeCategoryRepository.saveAll(categoriesToSave);
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/storecategory/application/config/StoreCategorySeedProperties.java
+++ b/src/main/java/com/sparta/spartadelivery/storecategory/application/config/StoreCategorySeedProperties.java
@@ -1,0 +1,15 @@
+package com.sparta.spartadelivery.storecategory.application.config;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "app.seed.store-categories")
+public record StoreCategorySeedProperties(
+        boolean enabled,
+        List<String> values
+) {
+
+    public StoreCategorySeedProperties {
+        values = values == null ? List.of() : List.copyOf(values);
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -25,3 +25,13 @@ logging:
 jwt:
   secret: ${JWT_SECRET:please-change-this-secret-key-for-local-dev-at-least-32bytes}
   access-token-expiration: ${JWT_ACCESS_TOKEN_EXPIRATION:3600000}
+
+app:
+  seed:
+    store-categories:
+      enabled: true
+      values:
+        - 한식
+        - 중식
+        - 일식
+        - 양식

--- a/src/test/java/com/sparta/spartadelivery/store/application/StoreServiceTest.java
+++ b/src/test/java/com/sparta/spartadelivery/store/application/StoreServiceTest.java
@@ -1,0 +1,230 @@
+package com.sparta.spartadelivery.store.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.sparta.spartadelivery.area.domain.entity.Area;
+import com.sparta.spartadelivery.area.domain.repository.AreaRepository;
+import com.sparta.spartadelivery.area.exception.AreaErrorCode;
+import com.sparta.spartadelivery.auth.exception.AuthErrorCode;
+import com.sparta.spartadelivery.global.exception.AppException;
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.store.application.service.StoreService;
+import com.sparta.spartadelivery.store.domain.entity.Store;
+import com.sparta.spartadelivery.store.domain.repository.StoreRepository;
+import com.sparta.spartadelivery.store.exception.StoreErrorCode;
+import com.sparta.spartadelivery.store.presentation.dto.request.StoreCreateRequest;
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import com.sparta.spartadelivery.storecategory.domain.repository.StoreCategoryRepository;
+import com.sparta.spartadelivery.storecategory.exception.StoreCategoryErrorCode;
+import com.sparta.spartadelivery.user.domain.entity.Role;
+import com.sparta.spartadelivery.user.domain.entity.UserEntity;
+import com.sparta.spartadelivery.user.domain.repository.UserRepository;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class StoreServiceTest {
+
+    @Mock
+    private StoreRepository storeRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private StoreCategoryRepository storeCategoryRepository;
+
+    @Mock
+    private AreaRepository areaRepository;
+
+    @InjectMocks
+    private StoreService storeService;
+
+    @Test
+    @DisplayName("OWNER는 가게를 등록할 수 있다")
+    void createStoreByOwner() {
+        UUID storeCategoryId = UUID.randomUUID();
+        UUID areaId = UUID.randomUUID();
+        StoreCreateRequest request = new StoreCreateRequest(
+                storeCategoryId,
+                areaId,
+                " 스파르타 분식 ",
+                " 서울특별시 강남구 테헤란로 123 ",
+                " 02-1234-5678 "
+        );
+        UserPrincipal requester = principal(Role.OWNER);
+        UserEntity owner = ownerEntity(1L);
+        StoreCategory storeCategory = storeCategory(storeCategoryId);
+        Area area = area(areaId);
+
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(owner));
+        when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)).thenReturn(Optional.of(storeCategory));
+        when(areaRepository.findByIdAndDeletedAtIsNull(areaId)).thenReturn(Optional.of(area));
+        when(storeRepository.save(any(Store.class))).thenAnswer(invocation -> {
+            Store store = invocation.getArgument(0);
+            ReflectionTestUtils.setField(store, "id", UUID.randomUUID());
+            return store;
+        });
+
+        var response = storeService.createStore(request, requester);
+
+        ArgumentCaptor<Store> captor = ArgumentCaptor.forClass(Store.class);
+        verify(storeRepository).save(captor.capture());
+        Store savedStore = captor.getValue();
+        assertThat(savedStore.getOwner()).isEqualTo(owner);
+        assertThat(savedStore.getStoreCategory()).isEqualTo(storeCategory);
+        assertThat(savedStore.getArea()).isEqualTo(area);
+        assertThat(savedStore.getName()).isEqualTo("스파르타 분식");
+        assertThat(savedStore.getAddress()).isEqualTo("서울특별시 강남구 테헤란로 123");
+        assertThat(savedStore.getPhone()).isEqualTo("02-1234-5678");
+        assertThat(response.ownerId()).isEqualTo(owner.getId());
+        assertThat(response.storeCategoryId()).isEqualTo(storeCategoryId);
+        assertThat(response.areaId()).isEqualTo(areaId);
+        assertThat(response.name()).isEqualTo("스파르타 분식");
+    }
+
+    @Test
+    @DisplayName("OWNER가 아닌 사용자는 가게를 등록할 수 없다")
+    void createStoreByNonOwnerDenied() {
+        StoreCreateRequest request = new StoreCreateRequest(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "스파르타 분식",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678"
+        );
+        UserPrincipal requester = principal(Role.CUSTOMER);
+
+        assertThatThrownBy(() -> storeService.createStore(request, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreErrorCode.STORE_CREATE_OWNER_ROLE_REQUIRED);
+
+        verify(userRepository, never()).findByIdAndDeletedAtIsNull(any());
+        verify(storeRepository, never()).save(any());
+    }
+
+    @Test
+    @DisplayName("요청자 사용자가 없으면 가게를 등록할 수 없다")
+    void createStoreWhenOwnerNotFound() {
+        StoreCreateRequest request = new StoreCreateRequest(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "스파르타 분식",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678"
+        );
+        UserPrincipal requester = principal(Role.OWNER);
+
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> storeService.createStore(request, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(AuthErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("가게 카테고리가 없으면 가게를 등록할 수 없다")
+    void createStoreWhenStoreCategoryNotFound() {
+        UUID storeCategoryId = UUID.randomUUID();
+        UUID areaId = UUID.randomUUID();
+        StoreCreateRequest request = new StoreCreateRequest(
+                storeCategoryId,
+                areaId,
+                "스파르타 분식",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678"
+        );
+        UserPrincipal requester = principal(Role.OWNER);
+
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(ownerEntity(1L)));
+        when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> storeService.createStore(request, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("지역이 없으면 가게를 등록할 수 없다")
+    void createStoreWhenAreaNotFound() {
+        UUID storeCategoryId = UUID.randomUUID();
+        UUID areaId = UUID.randomUUID();
+        StoreCreateRequest request = new StoreCreateRequest(
+                storeCategoryId,
+                areaId,
+                "스파르타 분식",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678"
+        );
+        UserPrincipal requester = principal(Role.OWNER);
+
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(ownerEntity(1L)));
+        when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId))
+                .thenReturn(Optional.of(storeCategory(storeCategoryId)));
+        when(areaRepository.findByIdAndDeletedAtIsNull(areaId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> storeService.createStore(request, requester))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(AreaErrorCode.AREA_NOT_FOUND);
+    }
+
+    private UserPrincipal principal(Role role) {
+        return UserPrincipal.builder()
+                .id(1L)
+                .accountName("owner01")
+                .email("owner01@example.com")
+                .password("password")
+                .nickname("점주01")
+                .role(role)
+                .build();
+    }
+
+    private UserEntity ownerEntity(Long id) {
+        UserEntity owner = UserEntity.builder()
+                .username("owner01")
+                .nickname("점주01")
+                .email("owner01@example.com")
+                .password("password")
+                .role(Role.OWNER)
+                .isPublic(true)
+                .build();
+        ReflectionTestUtils.setField(owner, "id", id);
+        return owner;
+    }
+
+    private StoreCategory storeCategory(UUID id) {
+        StoreCategory storeCategory = StoreCategory.builder()
+                .name("분식")
+                .build();
+        ReflectionTestUtils.setField(storeCategory, "id", id);
+        return storeCategory;
+    }
+
+    private Area area(UUID id) {
+        Area area = Area.builder()
+                .name("강남")
+                .city("서울특별시")
+                .district("강남구")
+                .active(true)
+                .build();
+        ReflectionTestUtils.setField(area, "id", id);
+        return area;
+    }
+}

--- a/src/test/java/com/sparta/spartadelivery/store/presentation/controller/StoreControllerTest.java
+++ b/src/test/java/com/sparta/spartadelivery/store/presentation/controller/StoreControllerTest.java
@@ -1,0 +1,207 @@
+package com.sparta.spartadelivery.store.presentation.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.doAnswer;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.spartadelivery.area.exception.AreaErrorCode;
+import com.sparta.spartadelivery.global.exception.AppException;
+import com.sparta.spartadelivery.global.infrastructure.config.security.JwtAuthenticationFilter;
+import com.sparta.spartadelivery.global.infrastructure.config.security.JwtTokenProvider;
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.store.application.service.StoreService;
+import com.sparta.spartadelivery.store.exception.StoreErrorCode;
+import com.sparta.spartadelivery.store.presentation.dto.request.StoreCreateRequest;
+import com.sparta.spartadelivery.store.presentation.dto.response.StoreDetailResponse;
+import com.sparta.spartadelivery.user.domain.entity.Role;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(StoreController.class)
+@Import(StoreControllerTest.TestSecurityConfig.class)
+class StoreControllerTest {
+
+    @TestConfiguration
+    @EnableWebSecurity
+    static class TestSecurityConfig {
+        @Bean
+        public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+            http
+                    .csrf(AbstractHttpConfigurer::disable)
+                    .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                    .authorizeHttpRequests(auth -> auth.anyRequest().permitAll())
+                    .securityContext(context -> context.requireExplicitSave(false));
+            return http.build();
+        }
+    }
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private StoreService storeService;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    private UsernamePasswordAuthenticationToken ownerToken;
+
+    @BeforeEach
+    void setUp() throws Exception {
+        ownerToken = authenticationToken(Role.OWNER);
+
+        doAnswer(invocation -> {
+            jakarta.servlet.FilterChain chain = invocation.getArgument(2);
+            chain.doFilter(invocation.getArgument(0), invocation.getArgument(1));
+            return null;
+        }).when(jwtAuthenticationFilter).doFilter(any(), any(), any());
+    }
+
+    @Test
+    @DisplayName("가게 등록 성공 시 201 CREATED를 반환한다")
+    void createStore() throws Exception {
+        StoreCreateRequest request = new StoreCreateRequest(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "스파르타 분식",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678"
+        );
+        StoreDetailResponse response = storeResponse(request);
+
+        given(storeService.createStore(any(StoreCreateRequest.class), any(UserPrincipal.class)))
+                .willReturn(response);
+
+        mockMvc.perform(post("/api/v1/stores")
+                        .with(authentication(ownerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value(201))
+                .andExpect(jsonPath("$.message").value("CREATED"))
+                .andExpect(jsonPath("$.data.name").value("스파르타 분식"));
+    }
+
+    @Test
+    @DisplayName("가게 등록 요청값이 유효하지 않으면 400을 반환한다")
+    void createStoreWithInvalidRequest() throws Exception {
+        StoreCreateRequest request = new StoreCreateRequest(
+                null,
+                UUID.randomUUID(),
+                "",
+                "",
+                "02-1234-5678"
+        );
+
+        mockMvc.perform(post("/api/v1/stores")
+                        .with(authentication(ownerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.message").value("VALIDATION_ERROR"));
+    }
+
+    @Test
+    @DisplayName("OWNER가 아니면 가게 등록 시 403을 반환한다")
+    void createStoreByNonOwnerDenied() throws Exception {
+        StoreCreateRequest request = new StoreCreateRequest(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "스파르타 분식",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678"
+        );
+
+        given(storeService.createStore(any(StoreCreateRequest.class), any(UserPrincipal.class)))
+                .willThrow(new AppException(StoreErrorCode.STORE_CREATE_OWNER_ROLE_REQUIRED));
+
+        mockMvc.perform(post("/api/v1/stores")
+                        .with(authentication(ownerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("가게는 OWNER 권한 사용자만 등록할 수 있습니다."));
+    }
+
+    @Test
+    @DisplayName("지역이 없으면 가게 등록 시 404를 반환한다")
+    void createStoreWhenAreaNotFound() throws Exception {
+        StoreCreateRequest request = new StoreCreateRequest(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "스파르타 분식",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678"
+        );
+
+        given(storeService.createStore(any(StoreCreateRequest.class), any(UserPrincipal.class)))
+                .willThrow(new AppException(AreaErrorCode.AREA_NOT_FOUND));
+
+        mockMvc.perform(post("/api/v1/stores")
+                        .with(authentication(ownerToken))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.message").value("운영 지역을 찾을 수 없습니다."));
+    }
+
+    private StoreDetailResponse storeResponse(StoreCreateRequest request) {
+        return new StoreDetailResponse(
+                UUID.randomUUID(),
+                1L,
+                request.storeCategoryId(),
+                request.areaId(),
+                request.name(),
+                request.address(),
+                request.phone(),
+                BigDecimal.ZERO,
+                false,
+                LocalDateTime.now()
+        );
+    }
+
+    private UsernamePasswordAuthenticationToken authenticationToken(Role role) {
+        UserPrincipal userPrincipal = UserPrincipal.builder()
+                .id(1L)
+                .accountName("owner01")
+                .email("owner01@example.com")
+                .password("password")
+                .nickname("점주01")
+                .role(role)
+                .build();
+        return new UsernamePasswordAuthenticationToken(
+                userPrincipal,
+                null,
+                userPrincipal.getAuthorities()
+        );
+    }
+}

--- a/src/test/java/com/sparta/spartadelivery/store/presentation/dto/request/StoreCreateRequestTest.java
+++ b/src/test/java/com/sparta/spartadelivery/store/presentation/dto/request/StoreCreateRequestTest.java
@@ -1,0 +1,129 @@
+package com.sparta.spartadelivery.store.presentation.dto.request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import jakarta.validation.ValidatorFactory;
+import java.util.Set;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("StoreCreateRequest validation test")
+class StoreCreateRequestTest {
+
+    private static Validator validator;
+
+    @BeforeAll
+    static void setUp() {
+        ValidatorFactory factory = Validation.buildDefaultValidatorFactory();
+        validator = factory.getValidator();
+    }
+
+    @Test
+    @DisplayName("유효한 요청이면 위반이 없다")
+    void validRequest_NoViolations() {
+        StoreCreateRequest request = new StoreCreateRequest(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "스파르타 분식",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678"
+        );
+
+        Set<ConstraintViolation<StoreCreateRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isEmpty();
+    }
+
+    @Test
+    @DisplayName("storeCategoryId가 null이면 위반이 발생한다")
+    void storeCategoryId_Null_ViolationOccurs() {
+        StoreCreateRequest request = new StoreCreateRequest(
+                null,
+                UUID.randomUUID(),
+                "스파르타 분식",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678"
+        );
+
+        Set<ConstraintViolation<StoreCreateRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsExactly("가게 카테고리 ID는 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("areaId가 null이면 위반이 발생한다")
+    void areaId_Null_ViolationOccurs() {
+        StoreCreateRequest request = new StoreCreateRequest(
+                UUID.randomUUID(),
+                null,
+                "스파르타 분식",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678"
+        );
+
+        Set<ConstraintViolation<StoreCreateRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsExactly("지역 ID는 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("name이 공백이면 위반이 발생한다")
+    void name_Blank_ViolationOccurs() {
+        StoreCreateRequest request = new StoreCreateRequest(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "   ",
+                "서울특별시 강남구 테헤란로 123",
+                "02-1234-5678"
+        );
+
+        Set<ConstraintViolation<StoreCreateRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsExactly("가게명은 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("address가 공백이면 위반이 발생한다")
+    void address_Blank_ViolationOccurs() {
+        StoreCreateRequest request = new StoreCreateRequest(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "스파르타 분식",
+                "   ",
+                "02-1234-5678"
+        );
+
+        Set<ConstraintViolation<StoreCreateRequest>> violations = validator.validate(request);
+
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .containsExactly("가게 주소는 필수입니다.");
+    }
+
+    @Test
+    @DisplayName("phone은 null이어도 위반이 없다")
+    void phone_Null_NoViolation() {
+        StoreCreateRequest request = new StoreCreateRequest(
+                UUID.randomUUID(),
+                UUID.randomUUID(),
+                "스파르타 분식",
+                "서울특별시 강남구 테헤란로 123",
+                null
+        );
+
+        Set<ConstraintViolation<StoreCreateRequest>> violations = validator.validate(request);
+
+        assertThat(violations).isEmpty();
+    }
+}

--- a/src/test/java/com/sparta/spartadelivery/storecategory/application/bootstrap/StoreCategorySeederTest.java
+++ b/src/test/java/com/sparta/spartadelivery/storecategory/application/bootstrap/StoreCategorySeederTest.java
@@ -1,0 +1,77 @@
+package com.sparta.spartadelivery.storecategory.application.bootstrap;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.sparta.spartadelivery.storecategory.application.config.StoreCategorySeedProperties;
+import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
+import com.sparta.spartadelivery.storecategory.domain.repository.StoreCategoryRepository;
+import java.util.List;
+import java.util.stream.StreamSupport;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.boot.DefaultApplicationArguments;
+
+@ExtendWith(MockitoExtension.class)
+class StoreCategorySeederTest {
+
+    @Mock
+    private StoreCategoryRepository storeCategoryRepository;
+
+    private ArgumentCaptor<Iterable<StoreCategory>> categoriesCaptor;
+
+    @BeforeEach
+    @SuppressWarnings("unchecked")
+    void setUp() {
+        categoriesCaptor = ArgumentCaptor.forClass(Iterable.class);
+    }
+
+    @Test
+    @DisplayName("시드 데이터가 활성화되어 있으면 없는 카테고리만 저장한다")
+    void seedStoreCategories() throws Exception {
+        StoreCategorySeedProperties seedProperties = new StoreCategorySeedProperties(
+                true,
+                List.of("한식", " 중식 ", "한식", "", "일식")
+        );
+        StoreCategorySeeder seeder = new StoreCategorySeeder(storeCategoryRepository, seedProperties);
+
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("한식")).thenReturn(true);
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("중식")).thenReturn(false);
+        when(storeCategoryRepository.existsByNameAndDeletedAtIsNull("일식")).thenReturn(false);
+
+        seeder.run(new DefaultApplicationArguments(new String[0]));
+
+        verify(storeCategoryRepository).saveAll(categoriesCaptor.capture());
+        List<String> savedNames = toNames(categoriesCaptor.getValue());
+        assertThat(savedNames).containsExactly("중식", "일식");
+    }
+
+    @Test
+    @DisplayName("시드 데이터가 비활성화되어 있으면 저장하지 않는다")
+    void skipWhenSeedDisabled() throws Exception {
+        StoreCategorySeedProperties seedProperties = new StoreCategorySeedProperties(
+                false,
+                List.of("한식", "중식")
+        );
+        StoreCategorySeeder seeder = new StoreCategorySeeder(storeCategoryRepository, seedProperties);
+
+        seeder.run(new DefaultApplicationArguments(new String[0]));
+
+        verify(storeCategoryRepository, never()).existsByNameAndDeletedAtIsNull(any());
+        verify(storeCategoryRepository, never()).saveAll(any());
+    }
+
+    private List<String> toNames(Iterable<StoreCategory> categories) {
+        return StreamSupport.stream(categories.spliterator(), false)
+                .map(StoreCategory::getName)
+                .toList();
+    }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -16,3 +16,8 @@ spring:
 jwt:
   secret: test-secret-key-for-jwt-token-provider-at-least-32bytes
   access-token-expiration: 3600000
+
+app:
+  seed:
+    store-categories:
+      enabled: false


### PR DESCRIPTION
Ref #82 

## 작업 내용
- 가게 등록 Request DTO와 Response DTO를 추가했습니다.
- 가게 등록 시 사용하는 `StoreErrorCode`를 추가했습니다.
- 가게 등록 서비스 로직을 구현했습니다.
- 가게 등록 컨트롤러를 구현했습니다.
- 가게 등록 서비스 테스트를 추가했습니다.
- 가게 등록 컨트롤러 테스트를 추가했습니다.

## 주요 구현 사항
- `POST /api/v1/stores` 가게 등록 API 추가
- 로그인한 사용자를 가게 소유자로 저장하도록 처리
- `OWNER` 권한 사용자만 가게 등록 가능하도록 권한 검증 적용
- 삭제되지 않은 `StoreCategory`, `Area`, `User`만 참조할 수 있도록 검증 추가
- 가게명, 주소, 전화번호 입력값 정규화 처리

## 검증 내용
- `.\gradlew.bat test --tests com.sparta.spartadelivery.store.application.StoreServiceTest --tests com.sparta.spartadelivery.store.presentation.controller.StoreControllerTest`

## 참고 사항
- 현재 가게 등록 권한은 `OWNER`만 허용했습니다.
- 가게 등록 시 요청자 본인의 `UserEntity`를 owner로 사용합니다.