### PR TITLE
[FEAT] #11 메뉴 엔티티 추가

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/menu/domain/entity/Menu.java
+++ b/src/main/java/com/sparta/spartadelivery/menu/domain/entity/Menu.java
@@ -1,6 +1,7 @@
 package com.sparta.spartadelivery.menu.domain.entity;
 
 import com.sparta.spartadelivery.global.entity.BaseEntity;
+import com.sparta.spartadelivery.store.domain.entity.Store;
 import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -19,12 +20,13 @@ public class Menu extends BaseEntity {
     @Column(name = "menu_id")
     private UUID id;
 
-    /*
-    // 메뉴 여러 개는 한 가게에 속할 수 있습니다. (N : 1)
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "store_id", nullable = false)
-    private Store store;
-     */
+    // 메뉴 판매 가게 (N : 1)
+    @Column(name = "store_id", nullable = false)
+    private UUID storeId;
+
+    // 메뉴 카테고리 (N : 1)
+    @Column(name = "menu_category_id", nullable = false)
+    private UUID menuCategoryId;
 
     @Column(length = 100, nullable = false)
     private String name;
@@ -35,6 +37,15 @@ public class Menu extends BaseEntity {
     @Column(columnDefinition = "TEXT")
     private String description;
 
-    @Column(name = "is_hidden", nullable = false)
+    @Column(columnDefinition = "TEXT")
+    private String menuPictureUrl;
+
+    @Column(nullable = false)
     private Boolean isHidden = false;
+
+    @Column(columnDefinition = "TEXT")
+    private String aiDescription;
+
+    @Column(columnDefinition = "TEXT")
+    private String aiPrompt;
 }

--- a/src/main/java/com/sparta/spartadelivery/menu/domain/entity/MenuCategory.java
+++ b/src/main/java/com/sparta/spartadelivery/menu/domain/entity/MenuCategory.java
@@ -1,0 +1,51 @@
+package com.sparta.spartadelivery.menu.domain.entity;
+
+import com.sparta.spartadelivery.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "p_menu_category")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MenuCategory extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "menu_category_id")
+    private UUID id;
+
+    @Column(length = 50, nullable = false, unique = true)
+    private String name;
+
+    /*
+
+    // 상위 카테고리
+    @Column(nullable = True)
+    private UUID parent_id;
+
+
+    // 해당 메뉴 카테고리를 가진 가게 (N : 1)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "store_id", nullable = false)
+    private Store store;
+
+     */
+
+    /*
+
+    @Builder
+    private MenuCategory(String name) {
+        this.name = name;
+    }
+
+    public void update(String name) {
+        this.name = name;
+    }
+
+     */
+}

--- a/src/main/java/com/sparta/spartadelivery/menu/domain/entity/MenuTag.java
+++ b/src/main/java/com/sparta/spartadelivery/menu/domain/entity/MenuTag.java
@@ -1,0 +1,29 @@
+package com.sparta.spartadelivery.menu.domain.entity;
+
+import com.sparta.spartadelivery.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "p_menu_tag")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class MenuTag extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "menu_tag_id")
+    private UUID id;
+
+    // 메뉴 (N : 1)
+    @Column(name = "menu_id", nullable = false)
+    private UUID menuId;
+
+    // 태그 (N : 1)
+    @Column(name = "tag_id", nullable = false)
+    private UUID tagId;
+}

--- a/src/main/java/com/sparta/spartadelivery/menu/domain/entity/OptionGroupSpec.java
+++ b/src/main/java/com/sparta/spartadelivery/menu/domain/entity/OptionGroupSpec.java
@@ -1,0 +1,36 @@
+package com.sparta.spartadelivery.menu.domain.entity;
+
+import com.sparta.spartadelivery.global.entity.BaseEntity;
+import com.sparta.spartadelivery.user.domain.entity.UserEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_option_group_spec")
+public class OptionGroupSpec extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "option_group_spec_id")
+    private UUID id;
+
+    // 메뉴 (N : 1)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "menu_id", nullable = false)
+    private Menu menu;
+
+    @Column(length = 100, nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer minSelect = 0;
+
+    @Column(nullable = false)
+    private Integer maxSelect = 1;
+}

--- a/src/main/java/com/sparta/spartadelivery/menu/domain/entity/OptionSpec.java
+++ b/src/main/java/com/sparta/spartadelivery/menu/domain/entity/OptionSpec.java
@@ -1,0 +1,35 @@
+package com.sparta.spartadelivery.menu.domain.entity;
+
+import com.sparta.spartadelivery.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "p_option_spec")
+public class OptionSpec extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "option_spec_id")
+    private UUID id;
+
+    // 옵션 그룹 스펙 (N : 1)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "option_group_spec_id", nullable = false)
+    private OptionGroupSpec optionGroupSpec;
+
+    @Column(length = 100, nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Column(nullable = false)
+    private Boolean isDefault = false;
+}

--- a/src/main/java/com/sparta/spartadelivery/menu/domain/entity/Tag.java
+++ b/src/main/java/com/sparta/spartadelivery/menu/domain/entity/Tag.java
@@ -1,0 +1,24 @@
+package com.sparta.spartadelivery.menu.domain.entity;
+
+import com.sparta.spartadelivery.global.entity.BaseEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.UUID;
+
+@Entity
+@Getter
+@Table(name = "p_tag")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Tag extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.UUID)
+    @Column(name = "tag_id")
+    private UUID id;
+
+    @Column(length = 50, nullable = false, unique = true)
+    private String name;
+}

--- a/src/main/java/com/sparta/spartadelivery/menu/domain/repository/MenuCategoryRepository.java
+++ b/src/main/java/com/sparta/spartadelivery/menu/domain/repository/MenuCategoryRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.spartadelivery.menu.domain.repository;
+
+import com.sparta.spartadelivery.menu.domain.entity.Menu;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface MenuCategoryRepository extends JpaRepository<Menu, UUID> {
+}

--- a/src/main/java/com/sparta/spartadelivery/menu/domain/repository/MenuTagRepository.java
+++ b/src/main/java/com/sparta/spartadelivery/menu/domain/repository/MenuTagRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.spartadelivery.menu.domain.repository;
+
+import com.sparta.spartadelivery.menu.domain.entity.MenuTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface MenuTagRepository extends JpaRepository<MenuTag, UUID> {
+}

--- a/src/main/java/com/sparta/spartadelivery/menu/domain/repository/TagRepository.java
+++ b/src/main/java/com/sparta/spartadelivery/menu/domain/repository/TagRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.spartadelivery.menu.domain.repository;
+
+import com.sparta.spartadelivery.menu.domain.entity.Tag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.UUID;
+
+public interface TagRepository extends JpaRepository<Tag, UUID> {
+}


### PR DESCRIPTION
# 주요 변경사항

- Menu 도메인 엔티티 추가
- JPA Entity 매핑 설정

추가된 Entity는 다음과 같습니다.

- Tag
- OptionSpec
- OptionGroupSpec
- MenuCategory
- MenuTag
- Menu

- Spec은 차후 Option Snapshot이 필요할 경우를 대비해 미리 붙여둔 이름입니다. Spec 없이 각각 Option, OptionGroup이라고 생각하시면 됩니다!
EX) OptionGroup : 맛, 맵기, 사이즈 Option : 치즈맛, 간장맛, 1단계 매움, S, M, L ...