### PR TITLE
feat : Store entity 리뷰 평점 컬럼 분리 및 검색 기능 추가

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/global/infrastructure/config/AsyncConfig.java
+++ b/src/main/java/com/sparta/spartadelivery/global/infrastructure/config/AsyncConfig.java
@@ -1,0 +1,34 @@
+package com.sparta.spartadelivery.global.infrastructure.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig implements AsyncConfigurer {
+
+    @Override
+    public Executor getAsyncExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        // 핵심 쓰레드 수: 언제나 유지되는 쓰레드 개수
+        executor.setCorePoolSize(5);
+
+        // 최대 쓰레드 수: 큐가 찼을 때 확장되는 최대 개수
+        executor.setMaxPoolSize(10);
+
+        // 큐 용량: 작업 쓰레드가 corePoolSize만큼 찼을 때 대기하는 공간
+        executor.setQueueCapacity(500);
+
+        // 쓰레드 이름 접두사: 로그 확인 시 비동기 쓰레드임을 구분하기 위함
+        executor.setThreadNamePrefix("SpartaAsync-");
+
+        // 초기화 후 반환
+        executor.initialize();
+        return executor;
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/global/type/SortOrder.java
+++ b/src/main/java/com/sparta/spartadelivery/global/type/SortOrder.java
@@ -1,0 +1,13 @@
+package com.sparta.spartadelivery.global.type;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public enum SortOrder {
+    ASC("오름차순"),
+    DESC("내림차순");
+
+    private final String description;
+}

--- a/src/main/java/com/sparta/spartadelivery/review/domain/entity/Review.java
+++ b/src/main/java/com/sparta/spartadelivery/review/domain/entity/Review.java
@@ -1,16 +1,27 @@
 package com.sparta.spartadelivery.review.domain.entity;
 
 import com.sparta.spartadelivery.global.entity.BaseEntity;
+import com.sparta.spartadelivery.global.exception.AppException;
 import com.sparta.spartadelivery.order.domain.entity.Order;
+import com.sparta.spartadelivery.order.domain.entity.OrderStatus;
+import com.sparta.spartadelivery.review.domain.event.ReviewCreatedEvent;
+import com.sparta.spartadelivery.review.domain.event.ReviewDeletedEvent;
+import com.sparta.spartadelivery.review.domain.event.ReviewUpdatedEvent;
+import com.sparta.spartadelivery.review.exception.ReviewErrorCode;
 import com.sparta.spartadelivery.store.domain.entity.Store;
 import com.sparta.spartadelivery.user.domain.entity.UserEntity;
 import jakarta.persistence.*;
+import lombok.AccessLevel;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.domain.AfterDomainEventPublication;
+import org.springframework.data.domain.DomainEvents;
 
-import java.util.UUID;
+import java.util.*;
 
 @Getter
 @Entity
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Review extends BaseEntity {
 
     private static final int MIN_RATING = 1;
@@ -32,13 +43,31 @@ public class Review extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "user_id")
     private UserEntity customer;
+    @Column(name = "customer_id", nullable = false)
+    private Long customerId;
 
     private int rating;
 
     private String content;
 
-    protected Review() {
+    //region [도메인 이벤트 관리를 위한 필드]
+    @Transient
+    private final List<Object> domainEvents = new ArrayList<>();
+
+    @DomainEvents
+    public Collection<Object> domainEvents() {
+        return Collections.unmodifiableList(domainEvents);
     }
+
+    @AfterDomainEventPublication
+    public void clearDomainEvents() {
+        domainEvents.clear();
+    }
+
+    private void registerEvent(Object event) {
+        this.domainEvents.add(event);
+    }
+    //endregion
 
     public Review(UUID id, Order order, Store store, UserEntity customer, int rating, String content) {
         this.id = id;
@@ -48,6 +77,8 @@ public class Review extends BaseEntity {
         this.rating = rating;
         this.content = content;
         validate();
+
+        registerEvent(new ReviewCreatedEvent(this.store.getId(), this.rating));
     }
 
     public Review(Order order, Store store, UserEntity customer, int rating, String content) {
@@ -55,40 +86,48 @@ public class Review extends BaseEntity {
     }
 
     private void validate() {
-//        if (!Objects.equals(order.getCustomer().getId(), customer.getId())) {
-//            throw new IllegalStateException("주문자와 리뷰 작성자가 일치하지 않으면 리뷰 생성할 수 없습니다");
-//        }
-
-//        if (isOutOfRange(rating)) {
-//            throw new IllegalArgumentException(String.format("리뷰 점수는 %d부터 %d까지 입력할 수 있습니다.", MIN_RATING, MAX_RATING));
-//        }
-
-//        if (order.getStatus() != OrderStatus.COMPLETED) {
-//            throw new IllegalStateException("주문이 완료되지 않은 경우 리뷰를 생성할 수 없습니다");
-//        }
+        validateOrder(this.order);
+        validateRating(this.rating);
     }
 
     public void update(Long loginUserId, int rating, String content) {
+        int oldRating = this.rating;
+
         verifyCustomer(loginUserId);
         validateRating(rating);
+
         this.rating = rating;
         this.content = content;
+
+        registerEvent(new ReviewUpdatedEvent(this.store.getId(), oldRating, rating));
     }
 
     public void delete(Long loginUserId, String userName) {
         verifyCustomer(loginUserId);
         super.markDeleted(userName);
+
+        registerEvent(new ReviewDeletedEvent(this.store.getId(), this.rating));
+    }
+
+    private void validateOrder(Order order) {
+        if (!Objects.equals(order.getCustomerId(), customer.getId())) {
+            throw new AppException(ReviewErrorCode.ORDER_REVIEWER_MISMATCH_DENIED, "주문자와 리뷰 작성자가 일치하지 않으면 리뷰 생성할 수 없습니다");
+        }
+
+        if (order.getStatus() != OrderStatus.DELIVERED) {
+            throw new AppException(ReviewErrorCode.INVALID_ORDER_STATUS_DENIED, "주문이 완료되지 않은 경우 리뷰를 생성할 수 없습니다");
+        }
     }
 
     private void verifyCustomer(Long loginUserId) {
         if (!loginUserId.equals(this.customer.getId())) {
-            throw new IllegalArgumentException("리뷰 작성자만 수정 가능합니다");
+            throw new AppException(ReviewErrorCode.REVIEW_UPDATE_DENIED, "리뷰 작성자만 수정 가능합니다");
         }
     }
 
     private void validateRating(int rating) {
         if (isOutOfRange(rating))
-            throw new IllegalArgumentException(String.format("리뷰 점수는 %d부터 %d까지 입력할 수 있습니다.", MIN_RATING, MAX_RATING));
+            throw new AppException(ReviewErrorCode.REVIEW_INVALID_RATING_VALUE, String.format("리뷰 점수는 %d부터 %d까지 입력할 수 있습니다.", MIN_RATING, MAX_RATING));
     }
 
     private boolean isOutOfRange(int rating) {

--- a/src/main/java/com/sparta/spartadelivery/review/domain/event/ReviewCreatedEvent.java
+++ b/src/main/java/com/sparta/spartadelivery/review/domain/event/ReviewCreatedEvent.java
@@ -1,0 +1,6 @@
+package com.sparta.spartadelivery.review.domain.event;
+
+import java.util.UUID;
+
+public record ReviewCreatedEvent(UUID storeId, int rating) {
+}

--- a/src/main/java/com/sparta/spartadelivery/review/domain/event/ReviewDeletedEvent.java
+++ b/src/main/java/com/sparta/spartadelivery/review/domain/event/ReviewDeletedEvent.java
@@ -1,0 +1,6 @@
+package com.sparta.spartadelivery.review.domain.event;
+
+import java.util.UUID;
+
+public record ReviewDeletedEvent(UUID storeId, int rating) {
+}

--- a/src/main/java/com/sparta/spartadelivery/review/domain/event/ReviewUpdatedEvent.java
+++ b/src/main/java/com/sparta/spartadelivery/review/domain/event/ReviewUpdatedEvent.java
@@ -1,0 +1,6 @@
+package com.sparta.spartadelivery.review.domain.event;
+
+import java.util.UUID;
+
+public record ReviewUpdatedEvent(UUID storeId, int oldRating, int newRating) {
+}

--- a/src/main/java/com/sparta/spartadelivery/review/domain/repository/ReviewSearchRepository.java
+++ b/src/main/java/com/sparta/spartadelivery/review/domain/repository/ReviewSearchRepository.java
@@ -1,0 +1,9 @@
+package com.sparta.spartadelivery.review.domain.repository;
+
+import com.sparta.spartadelivery.review.domain.entity.Review;
+import com.sparta.spartadelivery.review.presentation.dto.ReviewSearchCondition;
+import org.springframework.data.domain.Slice;
+
+public interface ReviewSearchRepository {
+    Slice<Review> search(ReviewSearchCondition condition);
+}

--- a/src/main/java/com/sparta/spartadelivery/review/domain/repository/ReviewSearchRepositoryImpl.java
+++ b/src/main/java/com/sparta/spartadelivery/review/domain/repository/ReviewSearchRepositoryImpl.java
@@ -1,0 +1,75 @@
+package com.sparta.spartadelivery.review.domain.repository;
+
+import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.sparta.spartadelivery.global.type.SortOrder;
+import com.sparta.spartadelivery.review.domain.entity.Review;
+import com.sparta.spartadelivery.review.presentation.dto.ReviewSearchCondition;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Slice;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+import static com.sparta.spartadelivery.review.domain.entity.QReview.review;
+
+@Repository
+@RequiredArgsConstructor
+public class ReviewSearchRepositoryImpl implements ReviewSearchRepository {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Slice<Review> search(ReviewSearchCondition condition) {
+        int pageSize = condition.size();
+
+        List<Review> content = queryFactory
+                .selectFrom(review)
+                .where(
+                        review.store.id.eq(condition.storeId()),
+                        ratingEq(condition.rating())
+                )
+                // 정렬 기준 문자열과 방향 Enum을 함께 전달
+                .orderBy(getSort(condition.sortBy(), condition.sort()))
+                .offset((long) condition.page() * pageSize)
+                .limit(pageSize + 1)
+                .fetch();
+
+        boolean hasNext = false;
+        if (content.size() > pageSize) {
+            content.remove(pageSize);
+            hasNext = true;
+        }
+
+        return new SliceImpl<>(content, PageRequest.of(condition.page(), pageSize), hasNext);
+    }
+
+    private BooleanExpression ratingEq(Integer rating) {
+        return rating != null ? review.rating.eq(rating) : null;
+    }
+
+    /**
+     * 정렬 조건 처리
+     *
+     * @param sortBy 정렬 기준 (기본값: "createdAt")
+     * @param order  정렬 방향 (기본값: DESC)
+     */
+    private OrderSpecifier<?> getSort(String sortBy, SortOrder order) {
+        // 1. 방향 기본값 설정: ASC가 아니면 무조건 DESC
+        boolean isAsc = (order == SortOrder.ASC);
+
+        // 2. sortBy가 null이거나 빈 값이면 기본값 "createdAt" 적용
+        if (sortBy == null || sortBy.isBlank()) {
+            return isAsc ? review.createdAt.asc() : review.createdAt.desc();
+        }
+
+        // 3. 필드에 따른 분기 처리
+        return switch (sortBy) {
+            case "createdAt" -> isAsc ? review.createdAt.asc() : review.createdAt.desc();
+            default -> isAsc ? review.createdAt.asc() : review.createdAt.desc();
+        };
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/review/exception/ReviewErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/review/exception/ReviewErrorCode.java
@@ -1,0 +1,21 @@
+package com.sparta.spartadelivery.review.exception;
+
+import com.sparta.spartadelivery.global.exception.BaseErrorCode;
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ReviewErrorCode implements BaseErrorCode {
+    REVIEW_INVALID_RATING_VALUE(HttpStatus.BAD_REQUEST, "선택 가능한 리뷰 평점 범위를 벗어났습니다"),
+    ORDER_REVIEWER_MISMATCH_DENIED(HttpStatus.FORBIDDEN, "주문자와 리뷰 작성자가 일치하지 않으면 리뷰 생성할 수 없습니다"),
+    INVALID_ORDER_STATUS_DENIED(HttpStatus.FORBIDDEN, "주문이 완료되지 않은 경우 리뷰를 생성할 수 없습니다"),
+    REVIEW_UPDATE_DENIED(HttpStatus.FORBIDDEN, "본인이 작성한 리뷰만 수정 가능합니다");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ReviewErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/review/presentation/controller/ReviewApiSpecification.java
+++ b/src/main/java/com/sparta/spartadelivery/review/presentation/controller/ReviewApiSpecification.java
@@ -1,0 +1,47 @@
+package com.sparta.spartadelivery.review.presentation.controller;
+
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.global.presentation.dto.ApiResponse;
+import com.sparta.spartadelivery.review.presentation.dto.*;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import org.springframework.data.domain.Slice;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ModelAttribute;
+
+import java.util.UUID;
+
+@Tag(name = "Review API", description = "리뷰 관련 API")
+public interface ReviewApiSpecification {
+
+    @Operation(summary = "리뷰 작성", description = "배달 완료된 주문에 대해 리뷰를 작성합니다. (CUSTOMER 권한 필요)")
+    ResponseEntity<ApiResponse<ReviewDetailDto>> createReview(
+            @Parameter(description = "주문 ID", required = true) UUID orderId,
+            @Valid ReviewCreateRequest request
+    );
+
+    @Operation(summary = "리뷰 단건 상세 조회", description = "특정 리뷰의 상세 내용을 조회합니다.")
+    ResponseEntity<ApiResponse<ReviewDetailDto>> getViewDetail(
+            @Parameter(description = "리뷰 ID", required = true) UUID reviewId
+    );
+
+    @Operation(summary = "리뷰 수정", description = "작성한 리뷰의 별점 및 내용을 수정합니다. (작성자 본인만 가능)")
+    ResponseEntity<ApiResponse<Void>> update(
+            @Parameter(description = "리뷰 ID", required = true) UUID reviewId,
+            ReviewUpdateRequest request,
+            UserPrincipal updatedBy
+    );
+
+    @Operation(summary = "리뷰 삭제", description = "리뷰를 삭제(Soft Delete)합니다. (작성자 또는 관리자 권한 필요)")
+    ResponseEntity<ApiResponse<Void>> delete(
+            @Parameter(description = "리뷰 ID", required = true) UUID reviewId,
+            UserPrincipal deletedBy
+    );
+
+    @Operation(summary = "리뷰 목록 검색/페이징", description = "가게별 리뷰 목록을 검색합니다. (Slice 기반 페이징)")
+    ResponseEntity<ApiResponse<Slice<ReviewDetailDto>>> search(
+            @Valid @ModelAttribute ReviewSearchCondition condition
+    );
+}

--- a/src/main/java/com/sparta/spartadelivery/review/presentation/controller/ReviewController.java
+++ b/src/main/java/com/sparta/spartadelivery/review/presentation/controller/ReviewController.java
@@ -18,7 +18,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/reviews")
 @RestController
-public class ReviewController {
+public class ReviewController implements ReviewApiSpecification {
     private final ReviewService reviewService;
 
     @PreAuthorize("hasAnyRole('CUSTOMER')")

--- a/src/main/java/com/sparta/spartadelivery/review/presentation/controller/ReviewController.java
+++ b/src/main/java/com/sparta/spartadelivery/review/presentation/controller/ReviewController.java
@@ -2,11 +2,11 @@ package com.sparta.spartadelivery.review.presentation.controller;
 
 import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
 import com.sparta.spartadelivery.global.presentation.dto.ApiResponse;
-import com.sparta.spartadelivery.review.presentation.dto.ReviewDeletedInfoDto;
-import com.sparta.spartadelivery.review.presentation.dto.ReviewDetailDto;
-import com.sparta.spartadelivery.review.presentation.dto.ReviewUpdateRequest;
+import com.sparta.spartadelivery.review.presentation.dto.*;
 import com.sparta.spartadelivery.review.service.ReviewService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -20,6 +20,18 @@ import java.util.UUID;
 @RestController
 public class ReviewController {
     private final ReviewService reviewService;
+
+    @PreAuthorize("hasAnyRole('CUSTOMER')")
+    @PostMapping("/{orderId}")
+    public ResponseEntity<ApiResponse<ReviewDetailDto>> createReview(
+            @PathVariable UUID orderId,
+            @Valid @RequestBody ReviewCreateRequest request
+    ) {
+        ReviewDetailDto created = reviewService.create(orderId, request);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(ApiResponse.success(HttpStatus.CREATED.value(), created));
+    }
 
     @GetMapping("/{reviewId}")
     public ResponseEntity<ApiResponse<ReviewDetailDto>> getViewDetail(@PathVariable UUID reviewId) {
@@ -45,5 +57,13 @@ public class ReviewController {
         String deletedByName = deletedBy.getUsername();
         reviewService.delete(reviewId, new ReviewDeletedInfoDto(deletedById, deletedByName));
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), null));
+    }
+
+    @GetMapping
+    public ResponseEntity<ApiResponse<Slice<ReviewDetailDto>>> search(
+            @Valid ReviewSearchCondition condition
+    ) {
+        Slice<ReviewDetailDto> response = reviewService.search(condition);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), response));
     }
 }

--- a/src/main/java/com/sparta/spartadelivery/review/presentation/dto/ReviewCreateRequest.java
+++ b/src/main/java/com/sparta/spartadelivery/review/presentation/dto/ReviewCreateRequest.java
@@ -1,0 +1,26 @@
+package com.sparta.spartadelivery.review.presentation.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import java.util.UUID;
+
+public record ReviewCreateRequest(
+
+        @Schema(description = "가게 id")
+        @NotNull(message = "가게 ID는 필수입니다.")
+        UUID storeId,
+
+        @Schema(description = "유저 id")
+        @NotNull(message = "유저 ID는 필수입니다.")
+        Long customerId,
+
+        @Positive
+        @Schema(description = "평점")
+        int rating,
+
+        @Schema(description = "리뷰 내용")
+        String content
+) {
+}

--- a/src/main/java/com/sparta/spartadelivery/review/presentation/dto/ReviewDeletedInfoDto.java
+++ b/src/main/java/com/sparta/spartadelivery/review/presentation/dto/ReviewDeletedInfoDto.java
@@ -1,7 +1,14 @@
 package com.sparta.spartadelivery.review.presentation.dto;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotNull;
+
 public record ReviewDeletedInfoDto(
+        @Schema(description = "리뷰 삭제자의 userid")
+        @NotNull(message = "리뷰 삭제자의 userid는 필수입니다.")
         Long loginId,
+
+        @Schema(description = "리뷰 삭제자")
         String userName
 ) {
 }

--- a/src/main/java/com/sparta/spartadelivery/review/presentation/dto/ReviewDetailDto.java
+++ b/src/main/java/com/sparta/spartadelivery/review/presentation/dto/ReviewDetailDto.java
@@ -2,6 +2,7 @@ package com.sparta.spartadelivery.review.presentation.dto;
 
 import com.sparta.spartadelivery.review.domain.entity.Review;
 import io.swagger.v3.oas.annotations.media.Schema;
+import org.springframework.data.domain.Slice;
 
 import java.util.UUID;
 
@@ -26,5 +27,9 @@ public record ReviewDetailDto(
                 review.getContent()
 
         );
+    }
+
+    public static Slice<ReviewDetailDto> from(Slice<Review> reviewSlice) {
+        return reviewSlice.map(ReviewDetailDto::from);
     }
 }

--- a/src/main/java/com/sparta/spartadelivery/review/presentation/dto/ReviewSearchCondition.java
+++ b/src/main/java/com/sparta/spartadelivery/review/presentation/dto/ReviewSearchCondition.java
@@ -1,0 +1,34 @@
+package com.sparta.spartadelivery.review.presentation.dto;
+
+import com.sparta.spartadelivery.global.type.SortOrder;
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.UUID;
+
+public record ReviewSearchCondition(
+        @Schema(description = "가게 ID (필수)")
+        @NotNull(message = "가게 ID는 필수입니다.")
+        UUID storeId,
+
+        @Schema(description = "조회할 평점 (선택)", example = "5")
+        @Min(value = 1, message = "별점은 최소 1점 이상이어야 합니다.")
+        @Max(value = 5, message = "별점은 최대 5점 이하이어야 합니다.")
+        Integer rating,
+
+        @Schema(description = "페이지 번호 (0부터 시작)", example = "0", defaultValue = "0")
+        @Min(value = 0, message = "페이지 번호는 0 이상이어야 합니다.")
+        int page,
+
+        @Schema(description = "페이지당 데이터 개수", example = "10", defaultValue = "10")
+        int size,
+
+        @Schema(description = "정렬 기준 (기본값: createdAt)", example = "createdAt")
+        String sortBy,
+
+        @Schema(description = "정렬 방향 (기본값: DESC)", example = "DESC", allowableValues = {"ASC", "DESC"})
+        SortOrder sort
+) {
+}

--- a/src/main/java/com/sparta/spartadelivery/review/service/ReviewService.java
+++ b/src/main/java/com/sparta/spartadelivery/review/service/ReviewService.java
@@ -1,11 +1,18 @@
 package com.sparta.spartadelivery.review.service;
 
+import com.sparta.spartadelivery.order.domain.entity.Order;
+import com.sparta.spartadelivery.order.domain.repository.OrderRepository;
 import com.sparta.spartadelivery.review.domain.entity.Review;
 import com.sparta.spartadelivery.review.domain.repository.ReviewRepository;
-import com.sparta.spartadelivery.review.presentation.dto.ReviewDeletedInfoDto;
-import com.sparta.spartadelivery.review.presentation.dto.ReviewDetailDto;
-import com.sparta.spartadelivery.review.presentation.dto.ReviewUpdateRequest;
+import com.sparta.spartadelivery.review.domain.repository.ReviewSearchRepository;
+import com.sparta.spartadelivery.review.presentation.dto.*;
+import com.sparta.spartadelivery.store.domain.entity.Store;
+import com.sparta.spartadelivery.store.domain.repository.StoreRepository;
+import com.sparta.spartadelivery.user.domain.entity.UserEntity;
+import com.sparta.spartadelivery.user.domain.repository.UserRepository;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -15,24 +22,52 @@ import java.util.UUID;
 @RequiredArgsConstructor
 @Service
 public class ReviewService {
+
+    private final OrderRepository orderRepository;
+    private final StoreRepository storeRepository;
+    private final UserRepository userRepository;
     private final ReviewRepository reviewRepository;
+    private final ReviewSearchRepository reviewSearchRepository;
+
+    @Transactional
+    public ReviewDetailDto create(UUID orderId, ReviewCreateRequest request) {
+        Order order = orderRepository.findById(orderId)
+                .orElseThrow(() -> new EntityNotFoundException("주문을 찾을 수 없습니다. ID: " + orderId));
+        Store store = storeRepository.findById(request.storeId())
+                .orElseThrow(() -> new EntityNotFoundException("가게를 찾을 수 없습니다. ID: " + request.storeId()));
+        UserEntity customer = userRepository.findById(request.customerId())
+                .orElseThrow(() -> new EntityNotFoundException("유저를 찾을 수 없습니다. ID: " + request.customerId()));
+
+        Review saved = reviewRepository.save(
+                new Review(order, store, customer, request.rating(), request.content())
+        );
+        return ReviewDetailDto.from(saved);
+    }
 
     public ReviewDetailDto viewDetail(UUID reviewId) {
-        Review review = reviewRepository.getReferenceById(reviewId);
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new EntityNotFoundException("리뷰를 찾을 수 없습니다. ID: " + reviewId));
+
         return ReviewDetailDto.from(review);
     }
 
     @Transactional
     public void update(UUID reviewId, Long customerId, ReviewUpdateRequest request) {
-        Review review = reviewRepository.getReferenceById(reviewId);
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new EntityNotFoundException("리뷰를 찾을 수 없습니다. ID: " + reviewId));
         review.update(customerId, request.rating(), request.content());
     }
 
     @Transactional
     public void delete(UUID reviewId, ReviewDeletedInfoDto deletedInfo) {
-        Review review = reviewRepository.getReferenceById(reviewId);
+        Review review = reviewRepository.findById(reviewId)
+                .orElseThrow(() -> new EntityNotFoundException("리뷰를 찾을 수 없습니다. ID: " + reviewId));
         review.delete(deletedInfo.loginId(), deletedInfo.userName());
     }
 
-}
+    public Slice<ReviewDetailDto> search(ReviewSearchCondition condition) {
+        Slice<Review> reviews = reviewSearchRepository.search(condition);
+        return ReviewDetailDto.from(reviews);
+    }
 
+}

--- a/src/main/java/com/sparta/spartadelivery/store/application/listener/StoreEventListener.java
+++ b/src/main/java/com/sparta/spartadelivery/store/application/listener/StoreEventListener.java
@@ -1,0 +1,45 @@
+package com.sparta.spartadelivery.store.application.listener;
+
+import com.sparta.spartadelivery.review.domain.event.ReviewCreatedEvent;
+import com.sparta.spartadelivery.review.domain.event.ReviewDeletedEvent;
+import com.sparta.spartadelivery.review.domain.event.ReviewUpdatedEvent;
+import com.sparta.spartadelivery.store.domain.repository.StoreRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+@Component
+@RequiredArgsConstructor
+public class StoreEventListener {
+
+    private final StoreRepository storeRepository;
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleCreated(ReviewCreatedEvent event) {
+        // 평점 +N, 개수 +1
+        storeRepository.updateStoreRating(event.storeId(), event.rating(), 1);
+    }
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleUpdated(ReviewUpdatedEvent event) {
+        // 평점 차이(새점수 - 옛점수)만큼 합계 수정, 개수 변동 없음(0)
+        int delta = event.newRating() - event.oldRating();
+        storeRepository.updateStoreRating(event.storeId(), delta, 0);
+    }
+
+    @Async
+    @Transactional(propagation = Propagation.REQUIRES_NEW)
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleDeleted(ReviewDeletedEvent event) {
+        // 평점 -N, 개수 -1
+        storeRepository.updateStoreRating(event.storeId(), -event.rating(), -1);
+    }
+}

--- a/src/main/java/com/sparta/spartadelivery/store/domain/entity/Store.java
+++ b/src/main/java/com/sparta/spartadelivery/store/domain/entity/Store.java
@@ -4,21 +4,13 @@ import com.sparta.spartadelivery.area.domain.entity.Area;
 import com.sparta.spartadelivery.global.entity.BaseEntity;
 import com.sparta.spartadelivery.storecategory.domain.entity.StoreCategory;
 import com.sparta.spartadelivery.user.domain.entity.UserEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
-import java.math.BigDecimal;
-import java.util.UUID;
+import jakarta.persistence.*;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+
+import java.util.UUID;
 
 @Entity
 @Getter
@@ -52,8 +44,14 @@ public class Store extends BaseEntity {
     @Column(name = "phone", length = 20)
     private String phone;
 
-    @Column(name = "average_rating", precision = 2, scale = 1, nullable = false)
-    private BigDecimal averageRating = BigDecimal.ZERO;
+//    @Column(name = "average_rating", precision = 2, scale = 1, nullable = false)
+//    private BigDecimal averageRating = BigDecimal.ZERO;
+
+    @Column(name = "rating_sum")
+    private int ratingSum;
+
+    @Column(name = "rating_count")
+    private int ratingCount;
 
     @Column(name = "is_hidden", nullable = false)
     private boolean isHidden = false;
@@ -83,9 +81,9 @@ public class Store extends BaseEntity {
         this.phone = phone;
     }
 
-    public void updateAverageRating(BigDecimal averageRating) {
-        this.averageRating = averageRating;
-    }
+//    public void updateAverageRating(BigDecimal averageRating) {
+//        this.averageRating = averageRating;
+//    }
 
     public void hide() {
         this.isHidden = true;

--- a/src/main/java/com/sparta/spartadelivery/store/domain/repository/StoreRepository.java
+++ b/src/main/java/com/sparta/spartadelivery/store/domain/repository/StoreRepository.java
@@ -8,7 +8,9 @@ import java.util.UUID;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface StoreRepository extends JpaRepository<Store, UUID> {
 
@@ -25,4 +27,12 @@ public interface StoreRepository extends JpaRepository<Store, UUID> {
     Optional<Store> findByIdAndDeletedAtIsNullAndIsHiddenFalse(UUID id);
 
     Optional<Store> findByOwner(UserEntity user);
+
+    @Modifying(clearAutomatically = true)
+    @Query("UPDATE Store s SET s.ratingSum = s.ratingSum + :delta, " +
+            "s.ratingCount = s.ratingCount + :countDelta " +
+            "WHERE s.id = :id")
+    int updateStoreRating(@Param("id") UUID id,
+                          @Param("delta") int delta,
+                          @Param("countDelta") int countDelta);
 }

--- a/src/main/java/com/sparta/spartadelivery/store/presentation/dto/response/StoreDetailResponse.java
+++ b/src/main/java/com/sparta/spartadelivery/store/presentation/dto/response/StoreDetailResponse.java
@@ -2,7 +2,9 @@ package com.sparta.spartadelivery.store.presentation.dto.response;
 
 import com.sparta.spartadelivery.store.domain.entity.Store;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -47,9 +49,14 @@ public record StoreDetailResponse(
                 store.getName(),
                 store.getAddress(),
                 store.getPhone(),
-                store.getAverageRating(),
+                getAverageRating(store.getRatingSum(), store.getRatingCount()),
                 store.isHidden(),
                 store.getCreatedAt()
         );
+    }
+
+    private static BigDecimal getAverageRating(int ratingSum, int ratingCount) {
+        return BigDecimal.valueOf((double) ratingSum / ratingCount)
+                .setScale(1, RoundingMode.HALF_UP);
     }
 }

--- a/src/main/java/com/sparta/spartadelivery/store/presentation/dto/response/StoreDetailResponse.java
+++ b/src/main/java/com/sparta/spartadelivery/store/presentation/dto/response/StoreDetailResponse.java
@@ -56,7 +56,16 @@ public record StoreDetailResponse(
     }
 
     private static BigDecimal getAverageRating(int ratingSum, int ratingCount) {
-        return BigDecimal.valueOf((double) ratingSum / ratingCount)
+        // 1. 리뷰가 하나도 없는 경우(분모가 0) 처리
+        if (ratingCount == 0) {
+            return BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP);
+        }
+
+        // 2. NaN이나 Infinity 발생을 방지하기 위해 정수 연산 후 변환하거나,
+        // 값을 double로 만든 후 유효성 체크를 거칩니다.
+        double avg = (double) ratingSum / ratingCount;
+
+        return BigDecimal.valueOf(avg)
                 .setScale(1, RoundingMode.HALF_UP);
     }
 }

--- a/src/main/java/com/sparta/spartadelivery/store/presentation/dto/response/StoreListResponse.java
+++ b/src/main/java/com/sparta/spartadelivery/store/presentation/dto/response/StoreListResponse.java
@@ -44,7 +44,16 @@ public record StoreListResponse(
     }
 
     private static BigDecimal getAverageRating(int ratingSum, int ratingCount) {
-        return BigDecimal.valueOf((double) ratingSum / ratingCount)
+        // 1. 리뷰가 하나도 없는 경우(분모가 0) 처리
+        if (ratingCount == 0) {
+            return BigDecimal.ZERO.setScale(1, RoundingMode.HALF_UP);
+        }
+
+        // 2. NaN이나 Infinity 발생을 방지하기 위해 정수 연산 후 변환하거나,
+        // 값을 double로 만든 후 유효성 체크를 거칩니다.
+        double avg = (double) ratingSum / ratingCount;
+
+        return BigDecimal.valueOf(avg)
                 .setScale(1, RoundingMode.HALF_UP);
     }
 }

--- a/src/main/java/com/sparta/spartadelivery/store/presentation/dto/response/StoreListResponse.java
+++ b/src/main/java/com/sparta/spartadelivery/store/presentation/dto/response/StoreListResponse.java
@@ -2,7 +2,9 @@ package com.sparta.spartadelivery.store.presentation.dto.response;
 
 import com.sparta.spartadelivery.store.domain.entity.Store;
 import io.swagger.v3.oas.annotations.media.Schema;
+
 import java.math.BigDecimal;
+import java.math.RoundingMode;
 import java.time.LocalDateTime;
 import java.util.UUID;
 
@@ -35,9 +37,14 @@ public record StoreListResponse(
                 store.getStoreCategory().getName(),
                 store.getArea().getName(),
                 store.getName(),
-                store.getAverageRating(),
+                getAverageRating(store.getRatingSum(), store.getRatingCount()),
                 store.isHidden(),
                 store.getCreatedAt()
         );
+    }
+
+    private static BigDecimal getAverageRating(int ratingSum, int ratingCount) {
+        return BigDecimal.valueOf((double) ratingSum / ratingCount)
+                .setScale(1, RoundingMode.HALF_UP);
     }
 }

--- a/src/test/java/com/sparta/spartadelivery/review/domain/entity/ReviewTest.java
+++ b/src/test/java/com/sparta/spartadelivery/review/domain/entity/ReviewTest.java
@@ -1,0 +1,140 @@
+package com.sparta.spartadelivery.review.domain.entity;
+
+import com.sparta.spartadelivery.global.exception.AppException;
+import com.sparta.spartadelivery.order.domain.entity.Order;
+import com.sparta.spartadelivery.order.domain.entity.OrderStatus;
+import com.sparta.spartadelivery.store.domain.entity.Store;
+import com.sparta.spartadelivery.user.domain.entity.UserEntity;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewTest {
+
+    @Mock
+    private Order order;
+    @Mock
+    private Store store;
+    @Mock
+    private UserEntity customer;
+
+    private final Long CUSTOMER_ID = 1L;
+
+    @BeforeEach
+    void setUp() {
+        // 대부분의 검증에서 유저 ID 비교가 필요하므로 미리 설정
+        given(customer.getId()).willReturn(CUSTOMER_ID);
+    }
+
+    @Nested
+    @DisplayName("리뷰 생성 테스트")
+    class CreateReview {
+
+        @Test
+        @DisplayName("성공: 모든 조건이 충족되면 리뷰가 정상 생성된다")
+        void createReviewSuccess() {
+            // given
+            given(order.getCustomerId()).willReturn(CUSTOMER_ID);
+            given(order.getStatus()).willReturn(OrderStatus.DELIVERED);
+
+            // when
+            Review review = new Review(order, store, customer, 5, "정말 맛있어요!");
+
+            // then
+            assertThat(review.getRating()).isEqualTo(5);
+            assertThat(review.getContent()).isEqualTo("정말 맛있어요!");
+        }
+
+        @Test
+        @DisplayName("예외: 주문자와 리뷰 작성자가 다르면 생성에 실패한다")
+        void createReviewFail_UserMismatch() {
+            // given
+            given(order.getCustomerId()).willReturn(999L); // 다른 유저 ID
+
+            // when & then
+            assertThatThrownBy(() -> new Review(order, store, customer, 5, "실패 케이스"))
+                    .isInstanceOf(AppException.class)
+                    .hasMessageContaining("주문자와 리뷰 작성자가 일치하지 않으면");
+        }
+
+        @Test
+        @DisplayName("예외: 주문 상태가 배달 완료(DELIVERED)가 아니면 생성에 실패한다")
+        void createReviewFail_InvalidOrderStatus() {
+            // given
+            given(order.getCustomerId()).willReturn(CUSTOMER_ID);
+            given(order.getStatus()).willReturn(OrderStatus.PENDING);
+
+            // when & then
+            assertThatThrownBy(() -> new Review(order, store, customer, 5, "실패 케이스"))
+                    .isInstanceOf(AppException.class)
+                    .hasMessageContaining("주문이 완료되지 않은 경우");
+        }
+
+        @Test
+        @DisplayName("예외: 별점이 1~5 범위를 벗어나면 생성에 실패한다")
+        void createReviewFail_InvalidRating() {
+            // given
+            given(order.getCustomerId()).willReturn(CUSTOMER_ID);
+            given(order.getStatus()).willReturn(OrderStatus.DELIVERED);
+
+            // when & then
+            assertThatThrownBy(() -> new Review(order, store, customer, 0, "0점은 안돼요"))
+                    .isInstanceOf(AppException.class)
+                    .hasMessageContaining("리뷰 점수는 1부터 5까지");
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 수정/삭제 테스트")
+    class UpdateAndDeleteReview {
+
+        private Review review;
+
+        @BeforeEach
+        void initReview() {
+            given(order.getCustomerId()).willReturn(CUSTOMER_ID);
+            given(order.getStatus()).willReturn(OrderStatus.DELIVERED);
+            review = new Review(order, store, customer, 5, "원래 내용");
+        }
+
+        @Test
+        @DisplayName("성공: 본인의 리뷰를 수정하면 내용이 변경된다")
+        void updateReviewSuccess() {
+            // when
+            review.update(CUSTOMER_ID, 4, "변경된 내용");
+
+            // then
+            assertThat(review.getRating()).isEqualTo(4);
+            assertThat(review.getContent()).isEqualTo("변경된 내용");
+        }
+
+        @Test
+        @DisplayName("예외: 타인의 리뷰를 수정하려 하면 실패한다")
+        void updateReviewFail_Forbidden() {
+            // when & then
+            assertThatThrownBy(() -> review.update(999L, 1, "남의 리뷰"))
+                    .isInstanceOf(AppException.class)
+                    .hasMessageContaining("리뷰 작성자만 수정 가능");
+        }
+
+        @Test
+        @DisplayName("성공: 본인의 리뷰를 삭제하면 Soft Delete 처리된다")
+        void deleteReviewSuccess() {
+            // when
+            review.delete(CUSTOMER_ID, "tester");
+
+            // then
+            assertThat(review.isDeleted()).isTrue();
+            assertThat(review.getDeletedBy()).isEqualTo("tester");
+        }
+    }
+}

--- a/src/test/java/com/sparta/spartadelivery/review/presentation/controller/ReviewControllerTest.java
+++ b/src/test/java/com/sparta/spartadelivery/review/presentation/controller/ReviewControllerTest.java
@@ -1,0 +1,123 @@
+package com.sparta.spartadelivery.review.presentation.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.sparta.spartadelivery.global.exception.AppException;
+import com.sparta.spartadelivery.global.infrastructure.config.security.JsonSecurityErrorResponder;
+import com.sparta.spartadelivery.global.infrastructure.config.security.JwtTokenProvider;
+import com.sparta.spartadelivery.global.infrastructure.config.security.UserPrincipal;
+import com.sparta.spartadelivery.review.exception.ReviewErrorCode;
+import com.sparta.spartadelivery.review.presentation.dto.ReviewDetailDto;
+import com.sparta.spartadelivery.review.presentation.dto.ReviewSearchCondition;
+import com.sparta.spartadelivery.review.presentation.dto.ReviewUpdateRequest;
+import com.sparta.spartadelivery.review.service.ReviewService;
+import com.sparta.spartadelivery.user.domain.entity.Role;
+import com.sparta.spartadelivery.user.domain.repository.UserRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.SliceImpl;
+import org.springframework.http.MediaType;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(ReviewController.class)
+class ReviewControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private ReviewService reviewService;
+
+    @MockitoBean
+    private UserRepository userRepository;
+
+    @MockitoBean
+    private JwtTokenProvider jwtTokenProvider;
+
+    @MockitoBean
+    private JsonSecurityErrorResponder jsonSecurityErrorResponder;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @Test
+    @WithMockUser
+    @DisplayName("리뷰 1건을 조회한다")
+    void getViewDetailSuccess() throws Exception {
+
+        UUID reviewId = UUID.randomUUID();
+        ReviewDetailDto response = new ReviewDetailDto(reviewId, UUID.randomUUID(), 1L, 5, "최고의 맛!");
+        given(reviewService.viewDetail(reviewId)).willReturn(response);
+
+        mockMvc.perform(get("/api/v1/reviews/{reviewId}", reviewId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.reviewId").value(reviewId.toString()))
+                .andExpect(jsonPath("$.data.content").value("최고의 맛!"));
+    }
+
+    @Test
+    @DisplayName("실패: 리뷰 작성자가 아닌 유저가 수정을 시도하면 에러를 반환한다")
+    void updateReviewFail_NotAuthor() throws Exception {
+        // given
+        UUID reviewId = UUID.randomUUID();
+        Long otherUserId = 999L; // 작성자가 아닌 다른 유저 ID
+        ReviewUpdateRequest request = new ReviewUpdateRequest(4, "몰래 수정 시도");
+
+        UserPrincipal userPrincipal = UserPrincipal.builder()
+                .id(otherUserId)
+                .role(Role.CUSTOMER)
+                .build();
+
+        // 서비스에서 작성자 불일치 예외를 던지도록 설정
+        willThrow(new AppException(ReviewErrorCode.REVIEW_UPDATE_DENIED, "리뷰 작성자만 수정 가능합니다"))
+                .given(reviewService)
+                .update(eq(reviewId), eq(otherUserId), any(ReviewUpdateRequest.class));
+
+        // when & then
+        mockMvc.perform(put("/api/v1/reviews/{reviewId}", reviewId)
+                        .with(csrf())
+                        .with(user(userPrincipal))
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isForbidden())
+                .andExpect(jsonPath("$.message").value("리뷰 작성자만 수정 가능합니다"));
+    }
+
+    @Test
+    @WithMockUser
+    @DisplayName("리뷰를 조회한다")
+    void searchReviewsSuccess() throws Exception {
+
+        UUID storeId = UUID.randomUUID();
+        ReviewDetailDto dto = new ReviewDetailDto(UUID.randomUUID(), UUID.randomUUID(), 1L, 5, "맛있어요~");
+        SliceImpl<ReviewDetailDto> slice = new SliceImpl<>(List.of(dto), PageRequest.of(0, 10), false);
+
+        given(reviewService.search(any(ReviewSearchCondition.class))).willReturn(slice);
+
+        mockMvc.perform(get("/api/v1/reviews")
+                        .param("storeId", storeId.toString())
+                        .param("page", "0")
+                        .param("size", "10"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.data.content[0].content").value("맛있어요~"));
+
+    }
+}

--- a/src/test/java/com/sparta/spartadelivery/review/service/ReviewServiceTest.java
+++ b/src/test/java/com/sparta/spartadelivery/review/service/ReviewServiceTest.java
@@ -1,0 +1,148 @@
+package com.sparta.spartadelivery.review.service;
+
+import com.sparta.spartadelivery.global.exception.AppException;
+import com.sparta.spartadelivery.review.domain.entity.Review;
+import com.sparta.spartadelivery.review.domain.repository.ReviewRepository;
+import com.sparta.spartadelivery.review.domain.repository.ReviewSearchRepository;
+import com.sparta.spartadelivery.review.presentation.dto.ReviewDeletedInfoDto;
+import com.sparta.spartadelivery.review.presentation.dto.ReviewUpdateRequest;
+import jakarta.persistence.EntityNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class ReviewServiceTest {
+
+    @InjectMocks
+    private ReviewService reviewService;
+
+    @Mock
+    private ReviewRepository reviewRepository;
+
+    @Mock
+    private ReviewSearchRepository reviewSearchRepository;
+
+    @Nested
+    @DisplayName("리뷰 상세 조회 테스트")
+    class ViewDetail {
+        @Test
+        @DisplayName("존재하는 리뷰 ID로 조회하면 상세 정보를 반환한다")
+        void viewDetail_Success() {
+            // given
+//            UUID reviewId = UUID.randomUUID();
+//
+//            // 1. 필요한 연관 객체들 Mocking (엔티티 생성자에 필요)
+//            Order mockOrder = mock(Order.class);
+//            UserEntity mockUser = mock(UserEntity.class);
+//            Store mockStore = mock(Store.class);
+//
+//            // 2. Order에서 데이터가 나올 수 있도록 설정
+//            given(mockOrder.getCustomer()).willReturn(mockUser);
+//            given(mockOrder.getStore()).willReturn(mockStore);
+//            given(mockOrder.getStatus()).willReturn(OrderStatus.COMPLETED);
+//            given(mockUser.getId()).willReturn(1L);
+//
+//            // 3. 실제 Review 객체 생성 (Mock이 아님!)
+//            Review review = new Review(mockOrder, mockUser, 5, "맛있어요");
+//
+//            given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+//
+//            // when
+//            ReviewDetailDto result = reviewService.viewDetail(reviewId);
+//
+//            // then
+//            assertThat(result).isNotNull();
+//            // DTO에 데이터가 잘 들어갔는지 추가 검증 가능
+//            assertThat(result.content()).isEqualTo("맛있어요");
+//            verify(reviewRepository).findById(reviewId);
+        }
+
+        @Test
+        @DisplayName("존재하지 않는 리뷰 ID로 조회하면 EntityNotFoundException이 발생한다")
+        void viewDetail_Fail() {
+            // given
+            UUID reviewId = UUID.randomUUID();
+            given(reviewRepository.findById(reviewId)).willReturn(Optional.empty());
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.viewDetail(reviewId))
+                    .isInstanceOf(EntityNotFoundException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 수정 테스트")
+    class UpdateReview {
+        @Test
+        @DisplayName("작성자가 본인의 리뷰를 수정하면 성공한다")
+        void update_Success() {
+            // given
+            UUID reviewId = UUID.randomUUID();
+            Long customerId = 1L;
+            ReviewUpdateRequest request = new ReviewUpdateRequest(5, "수정된 내용");
+            Review review = mock(Review.class);
+
+            given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+            // when
+            reviewService.update(reviewId, customerId, request);
+
+            // then
+            // 엔티티의 update 메서드가 올바른 인자로 호출되었는지 확인
+            verify(review).update(customerId, request.rating(), request.content());
+        }
+
+        @Test
+        @DisplayName("작성자가 아닌 사람이 수정을 시도하면 예외가 발생한다")
+        void update_Fail_Unauthorized() {
+            // given
+            UUID reviewId = UUID.randomUUID();
+            Long strangerId = 999L;
+            ReviewUpdateRequest request = new ReviewUpdateRequest(5, "해킹 시도");
+            Review review = mock(Review.class);
+
+            given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+            // 엔티티 내부 검증에서 예외가 발생한다고 가정
+            doThrow(new AppException(null, "리뷰 작성자만 수정 가능합니다"))
+                    .when(review).update(anyLong(), anyInt(), anyString());
+
+            // when & then
+            assertThatThrownBy(() -> reviewService.update(reviewId, strangerId, request))
+                    .isInstanceOf(AppException.class);
+        }
+    }
+
+    @Nested
+    @DisplayName("리뷰 삭제 테스트")
+    class DeleteReview {
+        @Test
+        @DisplayName("정상적인 삭제 요청 시 soft delete가 수행된다")
+        void delete_Success() {
+            // given
+            UUID reviewId = UUID.randomUUID();
+            ReviewDeletedInfoDto deletedInfo = new ReviewDeletedInfoDto(1L, "홍길동");
+            Review review = mock(Review.class);
+
+            given(reviewRepository.findById(reviewId)).willReturn(Optional.of(review));
+
+            // when
+            reviewService.delete(reviewId, deletedInfo);
+
+            // then
+            verify(review).delete(deletedInfo.loginId(), deletedInfo.userName());
+        }
+    }
+}


### PR DESCRIPTION
### [AS-IS]
#### 리뷰 평점 조회를 하나에 컬럼에 저장하고 있었음
Store entity의 average_rating 컬럼
### [TO-BE]
#### 성능 이슈로 인한 컬럼 분리 
- **rating_sum(리뷰 평점 합), rating_count(리뷰 총 수)으로 분리 후, 조회하는 시점에 리뷰 평점 합/리뷰 총 수**로 리뷰 평점 조회
  - 리뷰 평점 평균만 저장하면 리뷰 수정이나 삭제 시 역산이 안 돼서 매번 리뷰 전체 재집계가 필요
-  리뷰 CUD 시, 리뷰 생성/수정/삭제 이벤트 발행 > 리뷰 이벤트 리스너가 리뷰 평점 합, 리뷰 총 수 update 하도록 수정

#### 리뷰 검색 추가
- 리뷰 검색 기능 추가
  - 평점 조건은 동적으로 선택되도록

#### 리뷰 코드 정리
- 불필요한 코드나 예외 메세지 등 정리
- swagger 추가