### PR TITLE
[FEAT] 가게 삭제 API 구현

### DIFF
--- a/src/main/java/com/sparta/spartadelivery/store/application/service/StoreService.java
+++ b/src/main/java/com/sparta/spartadelivery/store/application/service/StoreService.java
@@ -103,6 +103,15 @@ public class StoreService {
         return StoreDetailResponse.from(store);
     }
 
+    @Transactional
+    public void deleteStore(UUID storeId, UserPrincipal requester) {
+        Store store = storeRepository.findByIdAndDeletedAtIsNull(storeId)
+                .orElseThrow(() -> new AppException(StoreErrorCode.STORE_NOT_FOUND));
+
+        validateDeletePermission(requester, store);
+        store.markDeleted(requester.getAccountName());
+    }
+
     public StorePageResponse getStores(int page, int size, String sort) {
         String normalizedSort = normalizeSort(sort);
         Pageable pageable = createPageable(page, size, normalizedSort);
@@ -170,6 +179,16 @@ public class StoreService {
             return;
         }
         throw new AppException(StoreErrorCode.STORE_HIDE_ACCESS_DENIED);
+    }
+
+    private void validateDeletePermission(UserPrincipal requester, Store store) {
+        if (requester.getRole() == Role.MASTER) {
+            return;
+        }
+        if (requester.getRole() == Role.OWNER && store.getOwner().getId().equals(requester.getId())) {
+            return;
+        }
+        throw new AppException(StoreErrorCode.STORE_DELETE_ACCESS_DENIED);
     }
 
     private void validateAdminListPermission(UserPrincipal requester) {

--- a/src/main/java/com/sparta/spartadelivery/store/exception/StoreErrorCode.java
+++ b/src/main/java/com/sparta/spartadelivery/store/exception/StoreErrorCode.java
@@ -10,6 +10,7 @@ public enum StoreErrorCode implements BaseErrorCode {
     STORE_CREATE_OWNER_ROLE_REQUIRED(HttpStatus.FORBIDDEN, "가게는 OWNER 권한 사용자만 등록할 수 있습니다."),
     STORE_UPDATE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "가게를 수정할 권한이 없습니다."),
     STORE_HIDE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "가게를 숨김 처리할 권한이 없습니다."),
+    STORE_DELETE_ACCESS_DENIED(HttpStatus.FORBIDDEN, "가게를 삭제할 권한이 없습니다."),
     STORE_ADMIN_LIST_ACCESS_DENIED(HttpStatus.FORBIDDEN, "관리자용 가게 목록을 조회할 권한이 없습니다."),
     STORE_LIST_INVALID_PAGE_NUMBER(HttpStatus.BAD_REQUEST, "페이지 번호는 0 이상이어야 합니다."),
     STORE_LIST_INVALID_PAGE_SIZE(HttpStatus.BAD_REQUEST, "페이지 크기는 10, 30, 50 중 하나여야 합니다."),

--- a/src/main/java/com/sparta/spartadelivery/store/presentation/controller/StoreController.java
+++ b/src/main/java/com/sparta/spartadelivery/store/presentation/controller/StoreController.java
@@ -16,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -64,6 +65,16 @@ public class StoreController {
     ) {
         StoreDetailResponse response = storeService.hideStore(storeId, userPrincipal);
         return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), response));
+    }
+
+    @Operation(summary = "가게 삭제 API")
+    @DeleteMapping("/{storeId}")
+    public ResponseEntity<ApiResponse<Void>> deleteStore(
+            @PathVariable UUID storeId,
+            @AuthenticationPrincipal UserPrincipal userPrincipal
+    ) {
+        storeService.deleteStore(storeId, userPrincipal);
+        return ResponseEntity.ok(ApiResponse.success(HttpStatus.OK.value(), null));
     }
 
     @Operation(summary = "가게 목록 조회 API")

--- a/src/test/java/com/sparta/spartadelivery/store/application/StoreServiceTest.java
+++ b/src/test/java/com/sparta/spartadelivery/store/application/StoreServiceTest.java
@@ -67,11 +67,11 @@ class StoreServiceTest {
                 storeCategoryId,
                 areaId,
                 " 스파르타 분식 ",
-                " 서울특별시 강남구 테헤란로 123 ",
+                " 서울 강남구 테헤란로 123 ",
                 " 02-1234-5678 "
         );
-        UserPrincipal requester = principal(1L, Role.OWNER);
-        UserEntity owner = ownerEntity(1L);
+        UserPrincipal requester = principal(1L, Role.OWNER, "owner01");
+        UserEntity owner = ownerEntity(1L, "owner01");
         StoreCategory storeCategory = storeCategory(storeCategoryId, "분식");
         Area area = area(areaId, "강남");
 
@@ -89,31 +89,26 @@ class StoreServiceTest {
         ArgumentCaptor<Store> captor = ArgumentCaptor.forClass(Store.class);
         verify(storeRepository).save(captor.capture());
         Store savedStore = captor.getValue();
-        assertThat(savedStore.getOwner()).isEqualTo(owner);
-        assertThat(savedStore.getStoreCategory()).isEqualTo(storeCategory);
-        assertThat(savedStore.getArea()).isEqualTo(area);
         assertThat(savedStore.getName()).isEqualTo("스파르타 분식");
-        assertThat(savedStore.getAddress()).isEqualTo("서울특별시 강남구 테헤란로 123");
+        assertThat(savedStore.getAddress()).isEqualTo("서울 강남구 테헤란로 123");
         assertThat(savedStore.getPhone()).isEqualTo("02-1234-5678");
         assertThat(response.ownerId()).isEqualTo(owner.getId());
         assertThat(response.storeCategoryId()).isEqualTo(storeCategoryId);
         assertThat(response.areaId()).isEqualTo(areaId);
-        assertThat(response.name()).isEqualTo("스파르타 분식");
     }
 
     @Test
-    @DisplayName("OWNER가 아닌 사용자는 가게를 등록할 수 없다")
+    @DisplayName("OWNER가 아니면 가게를 등록할 수 없다")
     void createStoreByNonOwnerDenied() {
         StoreCreateRequest request = new StoreCreateRequest(
                 UUID.randomUUID(),
                 UUID.randomUUID(),
                 "스파르타 분식",
-                "서울특별시 강남구 테헤란로 123",
+                "서울 강남구 테헤란로 123",
                 "02-1234-5678"
         );
-        UserPrincipal requester = principal(1L, Role.CUSTOMER);
 
-        assertThatThrownBy(() -> storeService.createStore(request, requester))
+        assertThatThrownBy(() -> storeService.createStore(request, principal(1L, Role.CUSTOMER, "customer01")))
                 .isInstanceOf(AppException.class)
                 .extracting("errorCode")
                 .isEqualTo(StoreErrorCode.STORE_CREATE_OWNER_ROLE_REQUIRED);
@@ -129,14 +124,12 @@ class StoreServiceTest {
                 UUID.randomUUID(),
                 UUID.randomUUID(),
                 "스파르타 분식",
-                "서울특별시 강남구 테헤란로 123",
+                "서울 강남구 테헤란로 123",
                 "02-1234-5678"
         );
-        UserPrincipal requester = principal(1L, Role.OWNER);
-
         when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> storeService.createStore(request, requester))
+        assertThatThrownBy(() -> storeService.createStore(request, principal(1L, Role.OWNER, "owner01")))
                 .isInstanceOf(AppException.class)
                 .extracting("errorCode")
                 .isEqualTo(AuthErrorCode.USER_NOT_FOUND);
@@ -150,15 +143,14 @@ class StoreServiceTest {
                 storeCategoryId,
                 UUID.randomUUID(),
                 "스파르타 분식",
-                "서울특별시 강남구 테헤란로 123",
+                "서울 강남구 테헤란로 123",
                 "02-1234-5678"
         );
-        UserPrincipal requester = principal(1L, Role.OWNER);
 
-        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(ownerEntity(1L)));
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(ownerEntity(1L, "owner01")));
         when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> storeService.createStore(request, requester))
+        assertThatThrownBy(() -> storeService.createStore(request, principal(1L, Role.OWNER, "owner01")))
                 .isInstanceOf(AppException.class)
                 .extracting("errorCode")
                 .isEqualTo(StoreCategoryErrorCode.STORE_CATEGORY_NOT_FOUND);
@@ -173,24 +165,23 @@ class StoreServiceTest {
                 storeCategoryId,
                 areaId,
                 "스파르타 분식",
-                "서울특별시 강남구 테헤란로 123",
+                "서울 강남구 테헤란로 123",
                 "02-1234-5678"
         );
-        UserPrincipal requester = principal(1L, Role.OWNER);
 
-        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(ownerEntity(1L)));
+        when(userRepository.findByIdAndDeletedAtIsNull(1L)).thenReturn(Optional.of(ownerEntity(1L, "owner01")));
         when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId))
                 .thenReturn(Optional.of(storeCategory(storeCategoryId, "분식")));
         when(areaRepository.findByIdAndDeletedAtIsNull(areaId)).thenReturn(Optional.empty());
 
-        assertThatThrownBy(() -> storeService.createStore(request, requester))
+        assertThatThrownBy(() -> storeService.createStore(request, principal(1L, Role.OWNER, "owner01")))
                 .isInstanceOf(AppException.class)
                 .extracting("errorCode")
                 .isEqualTo(AreaErrorCode.AREA_NOT_FOUND);
     }
 
     @Test
-    @DisplayName("점주는 본인 가게를 수정할 수 있다")
+    @DisplayName("OWNER는 본인 가게를 수정할 수 있다")
     void updateStoreByOwner() {
         UUID storeId = UUID.randomUUID();
         UUID storeCategoryId = UUID.randomUUID();
@@ -200,7 +191,7 @@ class StoreServiceTest {
                 storeCategoryId,
                 areaId,
                 " 스파르타 떡볶이 ",
-                " 서울특별시 서초구 강남대로 321 ",
+                " 서울 송파구 올림픽로 321 ",
                 " 02-9876-5432 "
         );
 
@@ -208,16 +199,14 @@ class StoreServiceTest {
         when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId))
                 .thenReturn(Optional.of(storeCategory(storeCategoryId, "분식")));
         when(areaRepository.findByIdAndDeletedAtIsNull(areaId))
-                .thenReturn(Optional.of(area(areaId, "서초")));
+                .thenReturn(Optional.of(area(areaId, "송파")));
 
-        var response = storeService.updateStore(storeId, request, principal(1L, Role.OWNER));
+        var response = storeService.updateStore(storeId, request, principal(1L, Role.OWNER, "owner01"));
 
         assertThat(store.getName()).isEqualTo("스파르타 떡볶이");
-        assertThat(store.getAddress()).isEqualTo("서울특별시 서초구 강남대로 321");
+        assertThat(store.getAddress()).isEqualTo("서울 송파구 올림픽로 321");
         assertThat(store.getPhone()).isEqualTo("02-9876-5432");
         assertThat(response.name()).isEqualTo("스파르타 떡볶이");
-        assertThat(response.storeCategoryId()).isEqualTo(storeCategoryId);
-        assertThat(response.areaId()).isEqualTo(areaId);
     }
 
     @Test
@@ -231,7 +220,7 @@ class StoreServiceTest {
                 storeCategoryId,
                 areaId,
                 "스파르타 떡볶이",
-                "서울특별시 서초구 강남대로 321",
+                "서울 송파구 올림픽로 321",
                 "02-9876-5432"
         );
 
@@ -239,9 +228,9 @@ class StoreServiceTest {
         when(storeCategoryRepository.findByIdAndDeletedAtIsNull(storeCategoryId))
                 .thenReturn(Optional.of(storeCategory(storeCategoryId, "분식")));
         when(areaRepository.findByIdAndDeletedAtIsNull(areaId))
-                .thenReturn(Optional.of(area(areaId, "서초")));
+                .thenReturn(Optional.of(area(areaId, "송파")));
 
-        var response = storeService.updateStore(storeId, request, principal(2L, Role.MANAGER));
+        var response = storeService.updateStore(storeId, request, principal(2L, Role.MANAGER, "manager01"));
 
         assertThat(response.name()).isEqualTo("스파르타 떡볶이");
         assertThat(store.getOwner().getId()).isEqualTo(1L);
@@ -256,13 +245,13 @@ class StoreServiceTest {
                 UUID.randomUUID(),
                 UUID.randomUUID(),
                 "스파르타 떡볶이",
-                "서울특별시 서초구 강남대로 321",
+                "서울 송파구 올림픽로 321",
                 "02-9876-5432"
         );
 
         when(storeRepository.findByIdAndDeletedAtIsNull(storeId)).thenReturn(Optional.of(store));
 
-        assertThatThrownBy(() -> storeService.updateStore(storeId, request, principal(2L, Role.OWNER)))
+        assertThatThrownBy(() -> storeService.updateStore(storeId, request, principal(2L, Role.OWNER, "owner02")))
                 .isInstanceOf(AppException.class)
                 .extracting("errorCode")
                 .isEqualTo(StoreErrorCode.STORE_UPDATE_ACCESS_DENIED);
@@ -277,26 +266,26 @@ class StoreServiceTest {
                 UUID.randomUUID(),
                 UUID.randomUUID(),
                 "스파르타 떡볶이",
-                "서울특별시 서초구 강남대로 321",
+                "서울 송파구 올림픽로 321",
                 "02-9876-5432"
         );
 
         when(storeRepository.findByIdAndDeletedAtIsNull(storeId)).thenReturn(Optional.of(store));
 
-        assertThatThrownBy(() -> storeService.updateStore(storeId, request, principal(3L, Role.CUSTOMER)))
+        assertThatThrownBy(() -> storeService.updateStore(storeId, request, principal(3L, Role.CUSTOMER, "customer01")))
                 .isInstanceOf(AppException.class)
                 .extracting("errorCode")
                 .isEqualTo(StoreErrorCode.STORE_UPDATE_ACCESS_DENIED);
     }
 
     @Test
-    @DisplayName("점주는 본인 가게를 숨김 처리할 수 있다")
+    @DisplayName("OWNER는 본인 가게를 숨김 처리할 수 있다")
     void hideStoreByOwner() {
         UUID storeId = UUID.randomUUID();
         Store store = store(storeId, 1L, "스파르타 분식", "분식", "강남");
         when(storeRepository.findByIdAndDeletedAtIsNull(storeId)).thenReturn(Optional.of(store));
 
-        var response = storeService.hideStore(storeId, principal(1L, Role.OWNER));
+        var response = storeService.hideStore(storeId, principal(1L, Role.OWNER, "owner01"));
 
         assertThat(store.isHidden()).isTrue();
         assertThat(response.hidden()).isTrue();
@@ -309,7 +298,7 @@ class StoreServiceTest {
         Store store = store(storeId, 1L, "스파르타 분식", "분식", "강남");
         when(storeRepository.findByIdAndDeletedAtIsNull(storeId)).thenReturn(Optional.of(store));
 
-        var response = storeService.hideStore(storeId, principal(2L, Role.MANAGER));
+        var response = storeService.hideStore(storeId, principal(2L, Role.MANAGER, "manager01"));
 
         assertThat(store.isHidden()).isTrue();
         assertThat(response.hidden()).isTrue();
@@ -322,7 +311,7 @@ class StoreServiceTest {
         Store store = store(storeId, 1L, "스파르타 분식", "분식", "강남");
         when(storeRepository.findByIdAndDeletedAtIsNull(storeId)).thenReturn(Optional.of(store));
 
-        assertThatThrownBy(() -> storeService.hideStore(storeId, principal(2L, Role.OWNER)))
+        assertThatThrownBy(() -> storeService.hideStore(storeId, principal(2L, Role.OWNER, "owner02")))
                 .isInstanceOf(AppException.class)
                 .extracting("errorCode")
                 .isEqualTo(StoreErrorCode.STORE_HIDE_ACCESS_DENIED);
@@ -335,14 +324,79 @@ class StoreServiceTest {
         Store store = store(storeId, 1L, "스파르타 분식", "분식", "강남");
         when(storeRepository.findByIdAndDeletedAtIsNull(storeId)).thenReturn(Optional.of(store));
 
-        assertThatThrownBy(() -> storeService.hideStore(storeId, principal(3L, Role.CUSTOMER)))
+        assertThatThrownBy(() -> storeService.hideStore(storeId, principal(3L, Role.CUSTOMER, "customer01")))
                 .isInstanceOf(AppException.class)
                 .extracting("errorCode")
                 .isEqualTo(StoreErrorCode.STORE_HIDE_ACCESS_DENIED);
     }
 
     @Test
-    @DisplayName("공개 가게 상세 정보를 조회한다")
+    @DisplayName("OWNER는 본인 가게를 삭제할 수 있다")
+    void deleteStoreByOwner() {
+        UUID storeId = UUID.randomUUID();
+        Store store = store(storeId, 1L, "스파르타 분식", "분식", "강남");
+        when(storeRepository.findByIdAndDeletedAtIsNull(storeId)).thenReturn(Optional.of(store));
+
+        storeService.deleteStore(storeId, principal(1L, Role.OWNER, "owner01"));
+
+        assertThat(store.isDeleted()).isTrue();
+        assertThat(store.getDeletedBy()).isEqualTo("owner01");
+        assertThat(store.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("MASTER는 가게를 삭제할 수 있다")
+    void deleteStoreByMaster() {
+        UUID storeId = UUID.randomUUID();
+        Store store = store(storeId, 1L, "스파르타 분식", "분식", "강남");
+        when(storeRepository.findByIdAndDeletedAtIsNull(storeId)).thenReturn(Optional.of(store));
+
+        storeService.deleteStore(storeId, principal(9L, Role.MASTER, "master01"));
+
+        assertThat(store.isDeleted()).isTrue();
+        assertThat(store.getDeletedBy()).isEqualTo("master01");
+    }
+
+    @Test
+    @DisplayName("본인 가게가 아닌 OWNER는 삭제할 수 없다")
+    void deleteStoreByAnotherOwnerDenied() {
+        UUID storeId = UUID.randomUUID();
+        Store store = store(storeId, 1L, "스파르타 분식", "분식", "강남");
+        when(storeRepository.findByIdAndDeletedAtIsNull(storeId)).thenReturn(Optional.of(store));
+
+        assertThatThrownBy(() -> storeService.deleteStore(storeId, principal(2L, Role.OWNER, "owner02")))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreErrorCode.STORE_DELETE_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("CUSTOMER는 가게를 삭제할 수 없다")
+    void deleteStoreByCustomerDenied() {
+        UUID storeId = UUID.randomUUID();
+        Store store = store(storeId, 1L, "스파르타 분식", "분식", "강남");
+        when(storeRepository.findByIdAndDeletedAtIsNull(storeId)).thenReturn(Optional.of(store));
+
+        assertThatThrownBy(() -> storeService.deleteStore(storeId, principal(3L, Role.CUSTOMER, "customer01")))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreErrorCode.STORE_DELETE_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("삭제 대상 가게가 없으면 예외가 발생한다")
+    void deleteStoreWhenNotFound() {
+        UUID storeId = UUID.randomUUID();
+        when(storeRepository.findByIdAndDeletedAtIsNull(storeId)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> storeService.deleteStore(storeId, principal(1L, Role.OWNER, "owner01")))
+                .isInstanceOf(AppException.class)
+                .extracting("errorCode")
+                .isEqualTo(StoreErrorCode.STORE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("공개 가게 상세 정보를 조회할 수 있다")
     void getStore() {
         UUID storeId = UUID.randomUUID();
         Store store = store(storeId, 1L, "스파르타 분식", "분식", "강남");
@@ -372,7 +426,7 @@ class StoreServiceTest {
     @DisplayName("일반 가게 목록은 숨김 가게를 제외하고 조회한다")
     void getStores() {
         Store first = store(UUID.randomUUID(), 1L, "스파르타 분식", "분식", "강남");
-        Store second = store(UUID.randomUUID(), 1L, "스파르타 치킨", "치킨", "서초");
+        Store second = store(UUID.randomUUID(), 1L, "스파르타 치킨", "치킨", "송파");
         PageRequest pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
         when(storeRepository.findAllPublicStores(pageable))
                 .thenReturn(new PageImpl<>(List.of(first, second), pageable, 2));
@@ -385,7 +439,7 @@ class StoreServiceTest {
     }
 
     @Test
-    @DisplayName("일반 가게 목록 조회 결과가 없으면 빈 목록을 반환한다")
+    @DisplayName("일반 가게 목록 결과가 없으면 빈 목록을 반환한다")
     void getStoresWithEmptyContent() {
         PageRequest pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
         when(storeRepository.findAllPublicStores(pageable))
@@ -399,10 +453,10 @@ class StoreServiceTest {
     }
 
     @Test
-    @DisplayName("관리자용 가게 목록은 hidden이 false면 숨김 가게를 제외한다")
+    @DisplayName("관리자 목록은 hidden=false면 숨김 가게를 제외한다")
     void getAdminStoresWithoutHidden() {
         Store visibleStore = store(UUID.randomUUID(), 1L, "스파르타 분식", "분식", "강남");
-        UserPrincipal requester = principal(2L, Role.MANAGER);
+        UserPrincipal requester = principal(2L, Role.MANAGER, "manager01");
         PageRequest pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
         when(storeRepository.findAllPublicStores(pageable))
                 .thenReturn(new PageImpl<>(List.of(visibleStore), pageable, 1));
@@ -414,11 +468,11 @@ class StoreServiceTest {
     }
 
     @Test
-    @DisplayName("관리자용 가게 목록은 hidden이 true면 숨김 가게를 포함한다")
+    @DisplayName("관리자 목록은 hidden=true면 숨김 가게를 포함한다")
     void getAdminStoresWithHidden() {
         Store visibleStore = store(UUID.randomUUID(), 1L, "스파르타 분식", "분식", "강남");
-        Store hiddenStore = hiddenStore(UUID.randomUUID(), 1L, "스파르타 치킨", "치킨", "서초");
-        UserPrincipal requester = principal(2L, Role.MANAGER);
+        Store hiddenStore = hiddenStore(UUID.randomUUID(), 1L, "스파르타 치킨", "치킨", "송파");
+        UserPrincipal requester = principal(2L, Role.MANAGER, "manager01");
         PageRequest pageable = PageRequest.of(0, 10, Sort.by(Sort.Direction.DESC, "createdAt"));
         when(storeRepository.findAllByDeletedAtIsNull(pageable))
                 .thenReturn(new PageImpl<>(List.of(visibleStore, hiddenStore), pageable, 2));
@@ -430,9 +484,9 @@ class StoreServiceTest {
     }
 
     @Test
-    @DisplayName("관리자 권한이 없으면 관리자용 가게 목록을 조회할 수 없다")
+    @DisplayName("관리자 권한이 없으면 관리자 목록을 조회할 수 없다")
     void getAdminStoresByCustomerDenied() {
-        UserPrincipal requester = principal(1L, Role.CUSTOMER);
+        UserPrincipal requester = principal(1L, Role.CUSTOMER, "customer01");
 
         assertThatThrownBy(() -> storeService.getAdminStores(requester, 0, 10, null, true))
                 .isInstanceOf(AppException.class)
@@ -485,22 +539,22 @@ class StoreServiceTest {
                 .isEqualTo(StoreErrorCode.STORE_LIST_UNSUPPORTED_SORT_DIRECTION);
     }
 
-    private UserPrincipal principal(Long id, Role role) {
+    private UserPrincipal principal(Long id, Role role, String accountName) {
         return UserPrincipal.builder()
                 .id(id)
-                .accountName("owner01")
-                .email("owner01@example.com")
+                .accountName(accountName)
+                .email(accountName + "@example.com")
                 .password("password")
-                .nickname("점주01")
+                .nickname(accountName)
                 .role(role)
                 .build();
     }
 
-    private UserEntity ownerEntity(Long id) {
+    private UserEntity ownerEntity(Long id, String username) {
         UserEntity owner = UserEntity.builder()
-                .username("owner01")
-                .nickname("점주01")
-                .email("owner01@example.com")
+                .username(username)
+                .nickname(username)
+                .email(username + "@example.com")
                 .password("password")
                 .role(Role.OWNER)
                 .isPublic(true)
@@ -529,7 +583,7 @@ class StoreServiceTest {
     }
 
     private Store store(UUID id, Long ownerId, String name, String categoryName, String areaName) {
-        UserEntity owner = ownerEntity(ownerId);
+        UserEntity owner = ownerEntity(ownerId, "owner" + ownerId);
         StoreCategory storeCategory = storeCategory(UUID.randomUUID(), categoryName);
         Area area = area(UUID.randomUUID(), areaName);
 
@@ -538,7 +592,7 @@ class StoreServiceTest {
                 .storeCategory(storeCategory)
                 .area(area)
                 .name(name)
-                .address("서울특별시 강남구 테헤란로 123")
+                .address("서울 강남구 테헤란로 123")
                 .phone("02-1234-5678")
                 .build();
         ReflectionTestUtils.setField(store, "id", id);

--- a/src/test/java/com/sparta/spartadelivery/store/presentation/controller/StoreControllerTest.java
+++ b/src/test/java/com/sparta/spartadelivery/store/presentation/controller/StoreControllerTest.java
@@ -2,8 +2,10 @@ package com.sparta.spartadelivery.store.presentation.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.BDDMockito.willThrow;
 import static org.mockito.Mockito.doAnswer;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.authentication;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
@@ -86,9 +88,9 @@ class StoreControllerTest {
 
     @BeforeEach
     void setUp() throws Exception {
-        ownerToken = authenticationToken(1L, Role.OWNER);
-        customerToken = authenticationToken(2L, Role.CUSTOMER);
-        managerToken = authenticationToken(3L, Role.MANAGER);
+        ownerToken = authenticationToken(1L, Role.OWNER, "owner01");
+        customerToken = authenticationToken(2L, Role.CUSTOMER, "customer01");
+        managerToken = authenticationToken(3L, Role.MANAGER, "manager01");
 
         doAnswer(invocation -> {
             jakarta.servlet.FilterChain chain = invocation.getArgument(2);
@@ -104,7 +106,7 @@ class StoreControllerTest {
                 UUID.randomUUID(),
                 UUID.randomUUID(),
                 "스파르타 분식",
-                "서울특별시 강남구 테헤란로 123",
+                "서울 강남구 테헤란로 123",
                 "02-1234-5678"
         );
         StoreDetailResponse response = storeResponse(request.name(), request.storeCategoryId(), request.areaId(), false);
@@ -148,7 +150,7 @@ class StoreControllerTest {
                 UUID.randomUUID(),
                 UUID.randomUUID(),
                 "스파르타 분식",
-                "서울특별시 강남구 테헤란로 123",
+                "서울 강남구 테헤란로 123",
                 "02-1234-5678"
         );
 
@@ -169,7 +171,7 @@ class StoreControllerTest {
                 UUID.randomUUID(),
                 UUID.randomUUID(),
                 "스파르타 분식",
-                "서울특별시 강남구 테헤란로 123",
+                "서울 강남구 테헤란로 123",
                 "02-1234-5678"
         );
 
@@ -191,7 +193,7 @@ class StoreControllerTest {
                 UUID.randomUUID(),
                 UUID.randomUUID(),
                 "스파르타 떡볶이",
-                "서울특별시 서초구 강남대로 321",
+                "서울 송파구 올림픽로 321",
                 "02-9876-5432"
         );
         StoreDetailResponse response = storeResponse(request.name(), request.storeCategoryId(), request.areaId(), false);
@@ -237,7 +239,7 @@ class StoreControllerTest {
                 UUID.randomUUID(),
                 UUID.randomUUID(),
                 "스파르타 떡볶이",
-                "서울특별시 서초구 강남대로 321",
+                "서울 송파구 올림픽로 321",
                 "02-9876-5432"
         );
 
@@ -281,7 +283,44 @@ class StoreControllerTest {
     }
 
     @Test
-    @DisplayName("가게 상세조회 성공 시 200 OK를 반환한다")
+    @DisplayName("가게 삭제 성공 시 200 OK를 반환한다")
+    void deleteStore() throws Exception {
+        UUID storeId = UUID.randomUUID();
+
+        mockMvc.perform(delete("/api/v1/stores/{storeId}", storeId)
+                        .with(authentication(ownerToken)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value(200))
+                .andExpect(jsonPath("$.message").value("SUCCESS"))
+                .andExpect(jsonPath("$.data").doesNotExist());
+    }
+
+    @Test
+    @DisplayName("권한이 없으면 가게 삭제 시 403을 반환한다")
+    void deleteStoreDenied() throws Exception {
+        UUID storeId = UUID.randomUUID();
+        willThrow(new AppException(StoreErrorCode.STORE_DELETE_ACCESS_DENIED))
+                .given(storeService).deleteStore(any(UUID.class), any(UserPrincipal.class));
+
+        mockMvc.perform(delete("/api/v1/stores/{storeId}", storeId)
+                        .with(authentication(customerToken)))
+                .andExpect(status().isForbidden());
+    }
+
+    @Test
+    @DisplayName("삭제 대상 가게가 없으면 404를 반환한다")
+    void deleteStoreWhenNotFound() throws Exception {
+        UUID storeId = UUID.randomUUID();
+        willThrow(new AppException(StoreErrorCode.STORE_NOT_FOUND))
+                .given(storeService).deleteStore(any(UUID.class), any(UserPrincipal.class));
+
+        mockMvc.perform(delete("/api/v1/stores/{storeId}", storeId)
+                        .with(authentication(ownerToken)))
+                .andExpect(status().isNotFound());
+    }
+
+    @Test
+    @DisplayName("가게 상세 조회 성공 시 200 OK를 반환한다")
     void getStore() throws Exception {
         UUID storeId = UUID.randomUUID();
         StoreDetailResponse response = new StoreDetailResponse(
@@ -290,7 +329,7 @@ class StoreControllerTest {
                 UUID.randomUUID(),
                 UUID.randomUUID(),
                 "스파르타 분식",
-                "서울특별시 강남구 테헤란로 123",
+                "서울 강남구 테헤란로 123",
                 "02-1234-5678",
                 BigDecimal.valueOf(4.5),
                 false,
@@ -308,7 +347,7 @@ class StoreControllerTest {
     }
 
     @Test
-    @DisplayName("존재하지 않는 가게면 상세조회 시 404를 반환한다")
+    @DisplayName("존재하지 않는 가게면 상세 조회 시 404를 반환한다")
     void getStoreWhenNotFound() throws Exception {
         UUID storeId = UUID.randomUUID();
         given(storeService.getStore(storeId))
@@ -325,7 +364,7 @@ class StoreControllerTest {
         StorePageResponse response = new StorePageResponse(
                 List.of(
                         storeListResponse("스파르타 분식", "분식", "강남"),
-                        storeListResponse("스파르타 치킨", "치킨", "서초")
+                        storeListResponse("스파르타 치킨", "치킨", "송파")
                 ),
                 0,
                 10,
@@ -356,7 +395,7 @@ class StoreControllerTest {
     }
 
     @Test
-    @DisplayName("관리자용 가게 목록 조회 시 hidden이 false면 숨김 제외 결과를 반환한다")
+    @DisplayName("관리자 가게 목록 조회 시 hidden=false면 숨김 제외 결과를 반환한다")
     void getAdminStoresWithoutHidden() throws Exception {
         StorePageResponse response = new StorePageResponse(
                 List.of(storeListResponse("스파르타 분식", "분식", "강남")),
@@ -378,12 +417,12 @@ class StoreControllerTest {
     }
 
     @Test
-    @DisplayName("관리자용 가게 목록 조회 시 hidden이 true면 숨김 포함 결과를 반환한다")
+    @DisplayName("관리자 가게 목록 조회 시 hidden=true면 숨김 포함 결과를 반환한다")
     void getAdminStoresWithHidden() throws Exception {
         StorePageResponse response = new StorePageResponse(
                 List.of(
                         storeListResponse("스파르타 분식", "분식", "강남"),
-                        hiddenStoreListResponse("스파르타 치킨", "치킨", "서초")
+                        hiddenStoreListResponse("스파르타 치킨", "치킨", "송파")
                 ),
                 0,
                 10,
@@ -403,7 +442,7 @@ class StoreControllerTest {
     }
 
     @Test
-    @DisplayName("관리자 권한이 없으면 관리자용 가게 목록 조회 시 403을 반환한다")
+    @DisplayName("관리자 권한이 없으면 관리자 가게 목록 조회 시 403을 반환한다")
     void getAdminStoresByCustomerDenied() throws Exception {
         given(storeService.getAdminStores(any(UserPrincipal.class), any(Integer.class), any(Integer.class), any(), any(Boolean.class)))
                 .willThrow(new AppException(StoreErrorCode.STORE_ADMIN_LIST_ACCESS_DENIED));
@@ -421,7 +460,7 @@ class StoreControllerTest {
                 storeCategoryId,
                 areaId,
                 name,
-                "서울특별시 강남구 테헤란로 123",
+                "서울 강남구 테헤란로 123",
                 "02-1234-5678",
                 BigDecimal.ZERO,
                 hidden,
@@ -453,13 +492,13 @@ class StoreControllerTest {
         );
     }
 
-    private UsernamePasswordAuthenticationToken authenticationToken(Long id, Role role) {
+    private UsernamePasswordAuthenticationToken authenticationToken(Long id, Role role, String accountName) {
         UserPrincipal userPrincipal = UserPrincipal.builder()
                 .id(id)
-                .accountName(role == Role.OWNER ? "owner01" : "customer01")
-                .email(role == Role.OWNER ? "owner01@example.com" : "customer01@example.com")
+                .accountName(accountName)
+                .email(accountName + "@example.com")
                 .password("password")
-                .nickname(role == Role.OWNER ? "점주01" : "고객01")
+                .nickname(accountName)
                 .role(role)
                 .build();
         return new UsernamePasswordAuthenticationToken(


### PR DESCRIPTION
## 📝작업 내용
- `DELETE /api/v1/stores/{storeId}` 가게 삭제 API를 추가했습니다.
- OWNER는 본인 가게만 삭제할 수 있도록 권한 검증을 추가했습니다.
- MASTER는 가게 삭제가 가능하도록 정책을 반영했습니다.
- 가게 삭제는 hard delete가 아닌 soft delete로 처리하도록 구현했습니다.
- 삭제 권한 예외 코드를 추가했습니다.
- 가게 삭제 Service / Controller 테스트를 추가했습니다.
- 스토어 테스트 데이터를 현재 구현 기준에 맞게 정리했습니다.

## ✅검증 내용
- `./gradlew.bat test --tests "com.sparta.spartadelivery.store.application.StoreServiceTest" --tests "com.sparta.spartadelivery.store.presentation.controller.StoreControllerTest"`

## 💬리뷰 포인트
- 삭제 처리 시 `markDeleted(requester.getAccountName())`를 사용해 soft delete 이력을 남기도록 했습니다.
- OWNER 삭제 권한은 `본인 소유 가게`로 제한했습니다.
- 삭제 응답은 별도 데이터 없이 `200 OK`로 반환하도록 맞췄습니다.